### PR TITLE
Refuse to run db/seeds.rb in production (closes #23, #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [Unreleased]
+
+### Security
+- `db/seeds.rb` now refuses to run against `production` (closes #23, #24). The
+  script is destructive (`User.delete_all`, etc.) and creates a demo user with
+  a hardcoded password — both intentional for local dev and unsafe for prod.
+- `README.md` no longer instructs running `heroku run rails db:seed`. Real
+  users should sign up through the UI on the live deployment.
+
 ## [v1.1.0] — 2026-04-27 — User Authentication & Per-User Data
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -51,11 +51,16 @@ First-time setup from the project root:
 heroku create stay-in-touch-<team-suffix>        # pick a unique suffix
 heroku addons:create heroku-postgresql:essential-0
 git push heroku claude/m0-rails-foundation:main   # or main once merged
-heroku run rails db:seed
 heroku open
 ```
 
 The `Procfile` runs `rails db:migrate` automatically in the release phase, so subsequent deploys just need `git push heroku main`.
+
+> **Do not run `rails db:seed` against production.** The seed file is
+> development-only — it deletes every row in the People, Events, and Users
+> tables and creates a demo account whose password is committed to this
+> repo. The script will refuse to run if `RAILS_ENV=production`. Sign up a
+> real account through the UI instead.
 
 ## Terminology
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,4 +1,15 @@
-# Idempotent seed script. `bin/rails db:seed` can be re-run safely.
+# Development/test-only seed script. Re-runnable: wipes every row in the
+# tables below and re-creates a demo user plus example data.
+#
+# Refuse to run against production: the script is destructive (User.delete_all
+# would wipe every real account) and creates a demo account whose password is
+# committed to this public repo. Both behaviors are intentional for local dev
+# and unsafe for prod. See GitHub issues #23 and #24.
+if Rails.env.production?
+  abort "db/seeds.rb is development-only — refusing to run in #{Rails.env}. " \
+        "If you really need to seed prod, do it from the rails console with explicit data."
+end
+
 # Delete order respects the foreign-key graph: join rows first, then Events,
 # then People, then Sessions, then Users.
 puts "Clearing existing data..."

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,123 @@
+# Database Schema
+
+Authoritative source: [`db/schema.rb`](../db/schema.rb). This document is a
+human-readable mirror — regenerate by re-running the analysis if you alter
+migrations.
+
+## Tables & Attributes
+
+### `users`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `email` | string | not null, unique | |
+| `password_digest` | string | not null | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+### `sessions`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null | **FK → users.id** |
+| `ip_address` | string | nullable | |
+| `user_agent` | string | nullable | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+### `people`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null | **FK → users.id** |
+| `name` | string | not null | |
+| `email` | string | not null, unique per `user_id` | |
+| `timezone` | string | not null, default `"America/Chicago"` | |
+| `preferred_start_hour` | integer | not null, default 9 | |
+| `preferred_end_hour` | integer | not null, default 21 | |
+| `frequency_weeks` | decimal(5,2) | not null, default 4.0 | |
+| `notes` | text | nullable | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+### `events`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null | **FK → users.id** |
+| `occurred_at` | datetime | not null, indexed | |
+| `medium` | string | not null (`call`/`coffee`/`text`/`video`/`in_person`/`other`) | |
+| `title` | string | nullable | |
+| `notes` | text | nullable | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+### `event_participants`  *(join table)*
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `person_id` | integer | not null | **FK → people.id** |
+| `event_id` | integer | not null | **FK → events.id** |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Composite unique index on `(person_id, event_id)`.
+
+---
+
+## ER Diagram (cardinality)
+
+```
+                       ┌─────────────────────┐
+                       │       users         │
+                       │─────────────────────│
+                       │ PK  id              │
+                       │     email (unique)  │
+                       │     password_digest │
+                       └─────────┬───────────┘
+                                 │ 1
+                ┌────────────────┼────────────────┐
+                │ M              │ M              │ M
+                ▼                ▼                ▼
+      ┌──────────────┐   ┌──────────────┐   ┌──────────────┐
+      │   sessions   │   │    people    │   │    events    │
+      │──────────────│   │──────────────│   │──────────────│
+      │ PK  id       │   │ PK  id       │   │ PK  id       │
+      │ FK  user_id  │   │ FK  user_id  │   │ FK  user_id  │
+      │     ip_addr. │   │     name     │   │     occurred │
+      │     ua       │   │     email    │   │     medium   │
+      └──────────────┘   │     tz       │   │     title    │
+                         │     pref_hrs │   │     notes    │
+                         │     freq_wks │   └──────┬───────┘
+                         │     notes    │          │
+                         └──────┬───────┘          │
+                                │ 1                │ 1
+                                │ M                │ M
+                                ▼                  ▼
+                         ┌─────────────────────────────┐
+                         │     event_participants      │
+                         │  (join table, many-to-many) │
+                         │─────────────────────────────│
+                         │ PK  id                      │
+                         │ FK  person_id               │
+                         │ FK  event_id                │
+                         │  unique(person_id,event_id) │
+                         └─────────────────────────────┘
+```
+
+## Relationships (cardinality summary)
+
+| Parent | Child | Cardinality | Notes |
+|---|---|---|---|
+| `users` | `sessions` | **one-to-many** | `dependent: :destroy` |
+| `users` | `people` | **one-to-many** | `dependent: :destroy` |
+| `users` | `events` | **one-to-many** | `dependent: :destroy` |
+| `people` | `event_participants` | **one-to-many** | `dependent: :destroy` |
+| `events` | `event_participants` | **one-to-many** | `dependent: :destroy` |
+| `people` ↔ `events` | (via `event_participants`) | **many-to-many** | enforced unique on the pair |
+
+Notable rules:
+
+- Each user's `people.email` is unique within their own scope (not globally).
+- Every `event` must have ≥1 participant (model-level validation).
+- `preferred_start_hour ≤ preferred_end_hour` (model-level validation).


### PR DESCRIPTION
## Summary
- `db/seeds.rb` now `abort`s if `Rails.env.production?` — it's destructive (`User.delete_all`, etc.) and bakes in a public demo password, so it must never run in prod
- `README.md` no longer instructs `heroku run rails db:seed`; added a callout warning that the seed is dev-only
- `CHANGELOG.md`: `[Unreleased] / Security` entry referencing the issues

Closes #23 (HIGH — hardcoded demo credentials exposed via the public repo + live Heroku URL)
Closes #24 (MEDIUM — destructive `delete_all` documented for production use)

## Note: code fix is necessary but not sufficient
The demo user (`demo@example.com` / `password12345`) **already exists in the production DB** because `db:seed` was run there once during setup. Merging this PR prevents the issue from recurring but does **not** remove the existing account. Whoever has Heroku access still needs to run, against `stay-in-touch-cs396`:

```bash
heroku run --app stay-in-touch-cs396 rails runner \
  "u = User.find_by(email: 'demo@example.com'); u&.destroy; puts(u ? 'demo user destroyed' : 'demo user not found')"
```

(or rotate the password if you'd rather keep the account around — but destroying it is cleaner; re-creating via the signup form takes one click).

## Test plan
- [x] `bundle exec rspec` — 70/70 pass
- [x] Dropped + recreated dev DB, `bin/rails db:seed` produces 1 user / 12 people / 15 events
- [x] `RAILS_ENV=production bin/rails runner "load 'db/seeds.rb'"` aborts with the expected message
- [ ] Reviewer confirms README change reads cleanly
