### PR TITLE
Accessibility: add skip-to-main-content link

### DIFF
--- a/app/assets/stylesheets/app.css
+++ b/app/assets/stylesheets/app.css
@@ -189,3 +189,25 @@ th a.sort-link.active {
 footer {
   font-size: 0.78rem;
 }
+
+/* ── Skip link ───────────────────────────────────────────── */
+.skip-link:focus,
+.skip-link:focus-visible {
+  position: fixed;
+  top: 0.5rem;
+  left: 0.5rem;
+  z-index: 1080;
+  padding: 0.5rem 0.85rem;
+  background: #4338CA;
+  color: #ffffff;
+  border-radius: 6px;
+  font-weight: 600;
+  text-decoration: none;
+  outline: 2px solid #ffffff;
+  outline-offset: 2px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+}
+
+#main-content:focus {
+  outline: none;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -35,9 +35,10 @@
   </head>
 
   <body class="d-flex flex-column min-vh-100">
+    <a class="skip-link visually-hidden-focusable" href="#main-content">Skip to main content</a>
     <%= render "shared/navbar" %>
 
-    <main class="container py-4 flex-grow-1">
+    <main id="main-content" tabindex="-1" class="container py-4 flex-grow-1">
       <%= render "shared/flash" %>
       <%= yield %>
     </main>


### PR DESCRIPTION
## Summary

- Adds a `Skip to main content` link as the first focusable element in the layout, using Bootstrap's `visually-hidden-focusable` utility so it only appears on keyboard focus.
- Adds `id="main-content"` and `tabindex="-1"` to the existing `<main>` element so the link can move focus there.
- Adds a `.skip-link` style block in `app.css` for the visible focus appearance (indigo background, white text, top-left fixed position).

Closes #71

## Test plan

- [ ] Load any page, press `Tab` once — the skip link appears at the top-left.
- [ ] Press `Enter` while focused on the skip link — focus moves to `<main>` past the navbar.
- [ ] Without keyboard focus, the link is invisible.
