### PR TITLE
Accessibility: consistent keyboard focus indicator

### DIFF
--- a/app/assets/stylesheets/app.css
+++ b/app/assets/stylesheets/app.css
@@ -189,3 +189,16 @@ th a.sort-link.active {
 footer {
   font-size: 0.78rem;
 }
+
+/* ── Keyboard focus indicator ────────────────────────────── */
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+.btn:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
+  outline: 2px solid #4338CA;
+  outline-offset: 2px;
+  box-shadow: none;
+}


### PR DESCRIPTION
## Summary

- Adds a global `:focus-visible` rule in `app.css` for `a, button, input, select, textarea, .btn, [tabindex]:not([tabindex="-1"])`.
- 2px indigo outline at 2px offset — clear on the white background, doesn't clash with inline styles on the custom Google OAuth button.

Closes #72

## Test plan

- [ ] Tab through the navbar, login form, sign-up form, people list, and a dropdown menu.
- [ ] Every focusable element shows a visible indigo focus ring.
- [ ] The password-toggle button (`tabindex="-1"`) is correctly skipped.
