### PR TITLE
Accessibility: raise color contrast to AAA on flagged elements

### DIFF
--- a/app/assets/stylesheets/app.css
+++ b/app/assets/stylesheets/app.css
@@ -1,12 +1,26 @@
 @import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap');
 
+/*
+ * Palette — verified against WCAG 2.1 (webaim.org/resources/contrastchecker)
+ *
+ *   body text  #111827 on #FFFFFF  17.74:1  AAA
+ *   primary    #FFFFFF on #4338CA   7.90:1  AAA   (was 6.29:1 on #4F46E5)
+ *   link       #3730A3 on #FFFFFF   9.93:1  AAA   (was 4.50:1 on #0d6efd)
+ *   muted      #4B5563 on #FFFFFF   7.56:1  AAA   (was 6.76:1 composited)
+ */
 :root {
   --bs-font-sans-serif: 'Plus Jakarta Sans', system-ui, sans-serif;
-  --bs-primary: #4F46E5;
-  --bs-primary-rgb: 79, 70, 229;
+  --bs-primary: #4338CA;
+  --bs-primary-rgb: 67, 56, 202;
   --bs-body-bg: #ffffff;
   --bs-border-color: #E5E7EB;
   --bs-card-border-color: #E5E7EB;
+  --bs-secondary-color: #4B5563;
+  --bs-secondary-color-rgb: 75, 85, 99;
+  --bs-link-color: #3730A3;
+  --bs-link-color-rgb: 55, 48, 163;
+  --bs-link-hover-color: #1E1B4B;
+  --bs-link-hover-color-rgb: 30, 27, 75;
 }
 
 body {
@@ -44,20 +58,20 @@ body {
 
 /* ── Buttons ─────────────────────────────────────────────── */
 .btn-primary {
-  background-color: #4F46E5;
-  border-color: #4F46E5;
-}
-.btn-primary:hover {
   background-color: #4338CA;
   border-color: #4338CA;
 }
+.btn-primary:hover {
+  background-color: #3730A3;
+  border-color: #3730A3;
+}
 .btn-outline-primary {
-  color: #4F46E5;
-  border-color: #4F46E5;
+  color: #4338CA;
+  border-color: #4338CA;
 }
 .btn-outline-primary:hover {
-  background-color: #4F46E5;
-  border-color: #4F46E5;
+  background-color: #4338CA;
+  border-color: #4338CA;
 }
 .btn {
   font-weight: 500;
@@ -159,7 +173,7 @@ th a.sort-link:hover {
   color: #111827;
 }
 th a.sort-link.active {
-  color: #4F46E5;
+  color: #4338CA;
 }
 
 /* ── Dropdown menus ──────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Resolves the 4 contrast failures reported by Skynet's accessibility scan (`Skynet-Technologies-Free-Accessibility-Checker-Report.pdf`). All four passed WCAG AA but failed AAA's 7:1 threshold. Token changes bring each above 7:1:

| Token | Before | After | New ratio on white |
|---|---|---|---|
| `text-muted` | `#585C5E` (composited rgba) | `#4B5563` | **7.56:1** AAA |
| `--bs-primary` (button bg, white text) | `#4F46E5` | `#4338CA` | **7.90:1** AAA |
| `--bs-link-color` | `#0d6efd` | `#3730A3` | **9.93:1** AAA |

Hover states darken to `#3730A3` / `#1E1B4B` to stay visible.

Status badges intentionally untouched — Skynet did not flag them, and they pass AA (5.30:1–9.37:1).

Skynet also reports a "Page must contain an H1" failure pointing at `<html lang="en">`. The login page does have `<h1 class="h3 mb-4 text-center">Log In</h1>` (`app/views/sessions/new.html.erb:7`). Skynet appears to have evaluated the root URL's redirect response. No fix needed.

Closes #73

## Test plan

- [ ] Open the deployed site, inspect the `Log In` button, `Sign up` link, "or" divider, and footer text. Confirm new colors render.
- [ ] Run each pair through [webaim.org/resources/contrastchecker](https://webaim.org/resources/contrastchecker/) — confirm AAA passes.
- [ ] Re-run Skynet's free checker on the deployed URL — confirm 0 contrast failures.
