### PR TITLE
Accessibility: simplify About and Privacy copy

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -7,8 +7,8 @@
 
     <div class="vstack gap-4">
       <section>
-        <p class="text-muted">Stay In Touch is a personal CRM for maintaining friendships intentionally. Track the people you care about, log your catch-ups, and see at a glance who you're overdue to reach out to — without the awkwardness of a formal reminder.</p>
-        <p class="text-muted">Built as a class project for Northwestern University's CS Software Studio course.</p>
+        <p class="text-muted">Stay In Touch is a personal CRM for keeping up with friends. Track the people you care about. Log your catch-ups. See at a glance who you owe a call. No formal reminder needed.</p>
+        <p class="text-muted">We built it as a class project for Northwestern's CS Software Studio.</p>
       </section>
 
       <section>

--- a/app/views/pages/privacy.html.erb
+++ b/app/views/pages/privacy.html.erb
@@ -18,20 +18,20 @@
 
       <section>
         <h2 class="h5 fw-semibold">How we use it</h2>
-        <p class="text-muted">Your data is used solely to provide the Stay In Touch service — showing you who to reach out to and keeping a history of your catch-ups. We do not sell, share, or use your data for advertising.</p>
+        <p class="text-muted">We use your data only to run the Stay In Touch service. That means showing you who to reach out to and saving a history of your catch-ups. We do not sell or share your data. We do not use it for ads.</p>
       </section>
 
       <section>
         <h2 class="h5 fw-semibold">How to request deletion</h2>
-        <p class="text-muted">To delete your account and all associated data, email us at
-          <a href="mailto:stayintouch.cs396@gmail.com">stayintouch.cs396@gmail.com</a>
-          with the subject line <em>"Delete my account"</em>. We will permanently remove your data within 7 days.
+        <p class="text-muted">Want to delete your account? Email us at
+          <a href="mailto:stayintouch.cs396@gmail.com">stayintouch.cs396@gmail.com</a>.
+          Use the subject line <em>"Delete my account"</em>. We will remove your data within 7 days.
         </p>
       </section>
 
       <section>
         <h2 class="h5 fw-semibold">Third-party services</h2>
-        <p class="text-muted">If you connect Google Calendar, we store an OAuth access token to write events on your behalf. You can disconnect this at any time from the People page. We do not read your existing calendar data.</p>
+        <p class="text-muted">If you connect Google Calendar, we store an OAuth access token. We use it to write events for you. You can disconnect at any time from the People page. We do not read your existing calendar data.</p>
       </section>
     </div>
 


### PR DESCRIPTION
## Summary

Rewrites long, multi-clause sentences and one passive-voice sentence on the About and Privacy pages so Hemingway shows no red flags and no passive-voice warnings.

Before / after example (About):
- Before: "Track the people you care about, log your catch-ups, and see at a glance who you're overdue to reach out to — without the awkwardness of a formal reminder." (31 words, em-dash)
- After: "Track the people you care about. Log your catch-ups. See at a glance who you owe a call. No formal reminder needed."

Before / after example (Privacy "How we use it"):
- Before: "Your data is used solely to provide the Stay In Touch service — showing you who to reach out to and keeping a history of your catch-ups." (passive voice)
- After: "We use your data only to run the Stay In Touch service. That means showing you who to reach out to and saving a history of your catch-ups."

Closes #74

## Test plan

- [ ] Paste the final About copy into hemingwayapp.com/readability-checker — confirm no red sentences, no passive-voice flags.
- [ ] Paste the final Privacy copy into Hemingway — same result.
- [ ] Existing links (`mailto:` and external) render correctly.
