### PR TITLE
fix timezone bug and add duration field to Log Event scheduling

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -68,8 +68,11 @@ class EventsController < ApplicationController
   end
 
   def find_scheduled_slot
-    window_days = params.dig(:event, :window_days).to_i
-    window_days = 3 if window_days < 1
+    window_days  = params.dig(:event, :window_days).to_i
+    window_days  = 3 if window_days < 1
+
+    duration_min = params.dig(:event, :duration_minutes).to_i
+    duration_min = 60 if duration_min < 15
 
     from_h, from_m = parse_time_param(params.dig(:event, :preferred_from))
     to_h,   _to_m  = parse_time_param(params.dig(:event, :preferred_to))
@@ -77,7 +80,12 @@ class EventsController < ApplicationController
 
     if current_user.google_calendar_connected?
       GoogleCalendarService.new(current_user)
-                           .find_earliest_slot(window_days: window_days, from_hour: from_h, to_hour: to_h)
+                           .find_earliest_slot(
+                             window_days:   window_days,
+                             from_hour:     from_h,
+                             to_hour:       to_h,
+                             slot_duration: duration_min.minutes
+                           )
     end || default_slot(window_days, from_h, from_m)
   end
 
@@ -111,6 +119,7 @@ class EventsController < ApplicationController
   def event_params
     permitted = params.require(:event).permit(
       :occurred_at,
+      :duration_minutes,
       :medium,
       :title,
       :notes,

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -1,9 +1,12 @@
 class EventMailer < ApplicationMailer
+  CHICAGO_TZ = "America/Chicago"
+
   def calendar_invite(event, person, organizer)
-    @event     = event
-    @person    = person
-    @organizer = organizer
-    @slot_time = event.occurred_at.in_time_zone(person.timezone.presence || "UTC")
+    @event          = event
+    @person         = person
+    @organizer      = organizer
+    @slot_time      = event.occurred_at.in_time_zone(person.timezone.presence || CHICAGO_TZ)
+    @duration_label = format_duration(event.duration_minutes || 60)
 
     attachments["invite.ics"] = {
       mime_type: "text/calendar; method=REQUEST",
@@ -19,9 +22,11 @@ class EventMailer < ApplicationMailer
   private
 
   def generate_ical
-    start_utc = @event.occurred_at.utc
-    end_utc   = (@event.occurred_at + 30.minutes).utc
-    fmt       = "%Y%m%dT%H%M%SZ"
+    tz_name     = CHICAGO_TZ
+    local_start = @event.occurred_at.in_time_zone(tz_name)
+    local_end   = local_start + (@event.duration_minutes || 60).minutes
+    fmt_local   = "%Y%m%dT%H%M%S"
+    fmt_utc     = "%Y%m%dT%H%M%SZ"
 
     lines = [
       "BEGIN:VCALENDAR",
@@ -31,9 +36,9 @@ class EventMailer < ApplicationMailer
       "METHOD:REQUEST",
       "BEGIN:VEVENT",
       "UID:event-#{@event.id}-#{SecureRandom.hex(6)}@stayintouch",
-      "DTSTAMP:#{Time.now.utc.strftime(fmt)}",
-      "DTSTART:#{start_utc.strftime(fmt)}",
-      "DTEND:#{end_utc.strftime(fmt)}",
+      "DTSTAMP:#{Time.now.utc.strftime(fmt_utc)}",
+      "DTSTART;TZID=#{tz_name}:#{local_start.strftime(fmt_local)}",
+      "DTEND;TZID=#{tz_name}:#{local_end.strftime(fmt_local)}",
       fold_line("SUMMARY:#{@event.display_title}"),
       fold_line("ORGANIZER;CN=\"#{@organizer.email}\":mailto:#{@organizer.email}"),
       fold_line("ATTENDEE;CUTYPE=INDIVIDUAL;ROLE=REQ-PARTICIPANT;PARTSTAT=NEEDS-ACTION;" \
@@ -45,6 +50,18 @@ class EventMailer < ApplicationMailer
     ]
 
     lines.join("\r\n") + "\r\n"
+  end
+
+  def format_duration(minutes)
+    case minutes.to_i
+    when 15  then "15 minutes"
+    when 30  then "30 minutes"
+    when 45  then "45 minutes"
+    when 60  then "1 hour"
+    when 90  then "1.5 hours"
+    when 120 then "2 hours"
+    else          "#{minutes} minutes"
+    end
   end
 
   def fold_line(line)

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -43,7 +43,7 @@ class GoogleCalendarService
   # Finds the earliest 15-min-aligned free 30-min slot within the next window_days days,
   # restricted to hours [from_hour, to_hour) in the user's timezone. Returns a UTC Time,
   # or nil if no slot found.
-  def find_earliest_slot(window_days:, from_hour:, to_hour:, buffer: 15.minutes)
+  def find_earliest_slot(window_days:, from_hour:, to_hour:, slot_duration: 60.minutes, buffer: 15.minutes)
     service    = build_service
     now        = Time.current
     window_end = now + window_days.days
@@ -60,10 +60,10 @@ class GoogleCalendarService
     cursor = now.ceil(15.minutes)
     tz     = Time.zone
 
-    while cursor + 30.minutes <= window_end
+    while cursor + slot_duration <= window_end
       local = cursor.in_time_zone(tz)
       if local.hour >= from_hour && local.hour < to_hour
-        slot_end = cursor + 30.minutes
+        slot_end = cursor + slot_duration
         free = busy.none? { |s, e| cursor < e + buffer && slot_end > s - buffer }
         return cursor if free
       end
@@ -157,10 +157,11 @@ class GoogleCalendarService
 
   def build_calendar_event(event, people)
     # Use the first person's timezone for the event, falling back to UTC.
-    tz_name = people.first&.timezone.presence || "UTC"
+    tz_name  = people.first&.timezone.presence || "UTC"
+    duration = (event.duration_minutes.presence || 60).minutes
 
     start_time = event.occurred_at.in_time_zone(tz_name)
-    end_time   = start_time + 1.hour
+    end_time   = start_time + duration
 
     attendees = people.filter_map do |p|
       Google::Apis::CalendarV3::EventAttendee.new(email: p.email) if p.email.present?

--- a/app/views/event_mailer/calendar_invite.html.erb
+++ b/app/views/event_mailer/calendar_invite.html.erb
@@ -5,7 +5,7 @@
 <div class="event-card">
   <h2><%= @event.display_title %></h2>
   <p><strong>When:</strong> <%= @slot_time.strftime("%A, %B %-d at %-I:%M %p %Z") %></p>
-  <p><strong>Duration:</strong> 30 minutes</p>
+  <p><strong>Duration:</strong> <%= @duration_label %></p>
   <p><strong>Organized by:</strong> <%= @organizer.email %></p>
 </div>
 

--- a/app/views/event_mailer/calendar_invite.text.erb
+++ b/app/views/event_mailer/calendar_invite.text.erb
@@ -4,7 +4,7 @@ Hi <%= @person.name.split.first %>,
 
   <%= @event.display_title %>
   When: <%= @slot_time.strftime("%A, %B %-d at %-I:%M %p %Z") %>
-  Duration: 30 minutes
+  Duration: <%= @duration_label %>
   Organized by: <%= @organizer.email %>
 
 Open the attached .ics file to accept or decline this invitation.

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -44,6 +44,15 @@
   <% end %>
 
   <div>
+    <%= f.label :duration_minutes, "How long?", class: "form-label fw-semibold" %>
+    <%= f.select :duration_minutes,
+          [["15 minutes", 15], ["30 minutes", 30], ["45 minutes", 45],
+           ["1 hour", 60], ["1.5 hours", 90], ["2 hours", 120]],
+          { selected: (event.duration_minutes.presence || 60) },
+          class: "form-select" %>
+  </div>
+
+  <div>
     <%= f.label :medium, class: "form-label" %>
     <%= f.select :medium,
           Event::MEDIA.map { |m| [m.titleize, m] },

--- a/config/application.rb
+++ b/config/application.rb
@@ -25,6 +25,8 @@ module ProjectStayInTouch
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
 
+    config.time_zone = "America/Chicago"
+
     # Don't generate system test files.
     config.generators.system_tests = nil
   end

--- a/db/migrate/20260513200424_add_duration_minutes_to_events.rb
+++ b/db/migrate/20260513200424_add_duration_minutes_to_events.rb
@@ -1,0 +1,5 @@
+class AddDurationMinutesToEvents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :events, :duration_minutes, :integer, default: 60, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_04_180102) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_13_200424) do
   create_table "event_participants", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "event_id", null: false
@@ -23,6 +23,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_180102) do
 
   create_table "events", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.integer "duration_minutes", default: 60, null: false
     t.string "medium", null: false
     t.text "notes"
     t.datetime "occurred_at", null: false
@@ -47,13 +48,20 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_04_180102) do
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.decimal "frequency_weeks", precision: 5, scale: 2, default: "4.0", null: false
+    t.datetime "invited_at"
+    t.string "invitee_access_token"
+    t.string "invitee_refresh_token"
+    t.datetime "invitee_token_expires_at"
     t.string "name", null: false
     t.text "notes"
     t.integer "preferred_end_hour", default: 21, null: false
     t.integer "preferred_start_hour", default: 9, null: false
+    t.integer "scheduling_status", default: 0, null: false
+    t.string "scheduling_token"
     t.string "timezone", default: "America/Chicago", null: false
     t.datetime "updated_at", null: false
     t.integer "user_id", null: false
+    t.index ["scheduling_token"], name: "index_people_on_scheduling_token", unique: true
     t.index ["user_id", "email"], name: "index_people_on_user_id_and_email", unique: true
     t.index ["user_id"], name: "index_people_on_user_id"
   end


### PR DESCRIPTION
Set app timezone to America/Chicago so slot-hour comparisons and default slot computation use local time instead of UTC. Switch iCal DTSTART/DTEND to TZID=America/Chicago local-time format. Add duration_minutes column (default 60) and a How long? select to the form; thread the value through find_earliest_slot, build_calendar_event, and the iCal/email body so all calendar artefacts reflect the chosen duration.