### PR TITLE
Exploring graphs displays

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,6 @@ gem "ruby-openai"
 
 # CSV parsing (no longer in Ruby stdlib since Ruby 3.4)
 gem "csv"
+
+gem "chartkick"
+gem "groupdate"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -97,6 +97,7 @@ GEM
     bundler-audit (0.9.3)
       bundler (>= 1.2.0)
       thor (~> 1.0)
+    chartkick (5.2.1)
     childprocess (5.1.0)
       logger (~> 1.5)
     concurrent-ruby (1.3.6)
@@ -165,6 +166,8 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
+    groupdate (6.8.0)
+      activesupport (>= 7.2)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -426,6 +429,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   bundler-audit
+  chartkick
   csv
   debug
   dotenv-rails (~> 3.2)
@@ -434,6 +438,7 @@ DEPENDENCIES
   faker (~> 3.5)
   google-apis-calendar_v3 (~> 0.17)
   googleauth (~> 1.11)
+  groupdate
   importmap-rails
   overcommit
   pagy (~> 9.3)
@@ -475,6 +480,7 @@ CHECKSUMS
   brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
+  chartkick (5.2.1) sha256=2848d7de87189f30f28d077eb0bbdebc8a1f0f6f81de1ded95008fe564369949
   childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
@@ -504,6 +510,7 @@ CHECKSUMS
   google-cloud-env (2.3.1) sha256=0faac01eb27be78c2591d64433663b1a114f8f7af55a4f819755426cac9178e7
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   googleauth (1.16.2) sha256=15009502e2e38af71948cda918f230e27d327f6882a1e47967a5a4664930a638
+  groupdate (6.8.0) sha256=16f90ea18ca981c38e41e592416480b28353aa5e5cc3e7cb13a68b8fb5d40510
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   iniparse (1.5.0) sha256=36a165e98d8a250b7631c4a7f9afba32af78f089970cd6446a39771189c761f1

--- a/app/assets/stylesheets/app.css
+++ b/app/assets/stylesheets/app.css
@@ -404,3 +404,98 @@ turbo-frame#quick-log-modal.turbo-modal.is-open {
   overflow-y: auto;
   padding: 1.5rem;
 }
+
+/* ── Events calendar grid ────────────────────────────────── */
+.cal-grid {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+  border-left: 1px solid #e5e7eb;
+  border-top: 1px solid #e5e7eb;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+.cal-day-header {
+  padding: 0.4rem;
+  text-align: center;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: #6b7280;
+  background: #f9fafb;
+  border-right: 1px solid #e5e7eb;
+  border-bottom: 1px solid #e5e7eb;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.cal-day {
+  min-height: 100px;
+  padding: 0.3rem;
+  border-right: 1px solid #e5e7eb;
+  border-bottom: 1px solid #e5e7eb;
+  background: #fff;
+  vertical-align: top;
+}
+.cal-day--empty { background: #fafafa; }
+.cal-day--today { background: #faf5ff; }
+.cal-day-num {
+  display: block;
+  text-align: right;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 0.25rem;
+  line-height: 1;
+}
+.cal-day--today .cal-day-num {
+  color: #fff;
+  background: #4F46E5;
+  border-radius: 50%;
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  float: right;
+}
+.cal-event {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 3px;
+  border-radius: 3px;
+  background: #f3f4f6;
+  margin-bottom: 2px;
+  overflow: hidden;
+  cursor: pointer;
+}
+.cal-event-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.cal-event-title {
+  font-size: 0.68rem;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: 1;
+  min-width: 0;
+}
+.cal-event-people {
+  display: flex;
+  gap: 1px;
+  flex-shrink: 0;
+}
+.cal-more {
+  font-size: 0.62rem;
+  color: #9ca3af;
+  padding: 1px 3px;
+  display: block;
+}
+@media (max-width: 576px) {
+  .cal-day { min-height: 60px; padding: 0.15rem; }
+  .cal-event-people { display: none; }
+  .cal-event-title { font-size: 0.6rem; }
+  .cal-day-num { font-size: 0.7rem; }
+}

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -34,6 +34,16 @@ class DashboardController < ApplicationController
     @total_catchups = current_user.events.count
     @total_people   = current_user.people.count
 
+    @upcoming_birthdays = current_user.people.where.not(birthday: nil).select { |p|
+      bday = p.birthday.change(year: Date.current.year)
+      bday = bday.next_year if bday < Date.current
+      (bday - Date.current).to_i <= 30
+    }.sort_by { |p|
+      bday = p.birthday.change(year: Date.current.year)
+      bday = bday.next_year if bday < Date.current
+      (bday - Date.current).to_i
+    }
+
     @catchups_by_month = current_user.events
       .group_by_month(:occurred_at, last: 6)
       .count

--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -33,6 +33,16 @@ class DashboardController < ApplicationController
 
     @total_catchups = current_user.events.count
     @total_people   = current_user.people.count
+
+    @catchups_by_month = current_user.events
+      .group_by_month(:occurred_at, last: 6)
+      .count
+      .transform_keys { |d| d.strftime("%b %Y") }
+
+    @catchups_by_medium = current_user.events
+      .group(:medium)
+      .count
+      .transform_keys { |k| k.titleize }
   end
 
   def timeline

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -30,7 +30,8 @@ class EventsController < ApplicationController
         .distinct
     end
 
-    @events = events_scope.includes(:people).order(occurred_at: :desc)
+    @events = events_scope.includes(:people).order(occurred_at: :asc)
+    @events_by_day = @events.group_by { |e| e.occurred_at.to_date }
   end
 
   def show; end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -31,6 +31,12 @@ class PeopleController < ApplicationController
                                   .select { |p| !p.snoozed? && p.days_until_due&.negative? }
                                   .sort_by { |p| p.days_until_due }
                                   .first(3)
+
+    @upcoming_birthday_ids = current_user.people.where.not(birthday: nil).select { |p|
+      bday = p.birthday.change(year: Date.current.year)
+      bday = bday.next_year if bday < Date.current
+      (bday - Date.current).to_i <= 30
+    }.map(&:id).to_set
   end
 
   def show

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -128,6 +128,7 @@ class PeopleController < ApplicationController
       :frequency_weeks,
       :favorite,
       :notes,
+      :birthday,
       tag_ids: []
     )
   end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -118,6 +118,36 @@
 
   </div>
 
+  <%# Upcoming birthdays %>
+  <% if @upcoming_birthdays.any? %>
+    <div class="card mb-4" style="border-left: 4px solid #D97706; background:#FFFBEB;">
+      <div class="card-body py-3">
+        <h2 class="h6 fw-semibold mb-3" style="color:#92400E;">
+          <i class="bi bi-cake2 me-1"></i>Upcoming Birthdays
+        </h2>
+        <div class="d-flex flex-wrap gap-3">
+          <% @upcoming_birthdays.each do |person| %>
+            <% bday = person.birthday.change(year: Date.current.year) %>
+            <% bday = bday.next_year if bday < Date.current %>
+            <% days = (bday - Date.current).to_i %>
+            <div class="d-flex align-items-center gap-2">
+              <%= link_to person_path(person), class: "fw-semibold text-decoration-none text-dark" do %>
+                <%= person.name %>
+              <% end %>
+              <% if days == 0 %>
+                <span class="badge bg-warning text-dark">🎂 Today!</span>
+              <% else %>
+                <span class="badge" style="background:#FEF3C7; color:#92400E;">
+                  <%= bday.strftime("%b %-d") %> &middot; in <%= days %> <%= "day".pluralize(days) %>
+                </span>
+              <% end %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
   <%# Activity charts %>
   <div class="row g-3 mb-4">
     <div class="col-12 col-md-8">

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -118,6 +118,40 @@
 
   </div>
 
+  <%# Activity charts %>
+  <div class="row g-3 mb-4">
+    <div class="col-12 col-md-8">
+      <div class="card h-100">
+        <div class="card-body">
+          <h2 class="h6 fw-semibold mb-3">
+            <i class="bi bi-bar-chart me-1 text-muted"></i>Catch-ups per Month
+          </h2>
+          <%= column_chart @catchups_by_month,
+                colors: ["#4F46E5"],
+                height: "180px",
+                library: { scales: { y: { ticks: { precision: 0 }, beginAtZero: true } } } %>
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-md-4">
+      <div class="card h-100">
+        <div class="card-body">
+          <h2 class="h6 fw-semibold mb-3">
+            <i class="bi bi-pie-chart me-1 text-muted"></i>By Medium
+          </h2>
+          <% if @catchups_by_medium.any? %>
+            <%= pie_chart @catchups_by_medium,
+                  colors: ["#4F46E5", "#0D9488", "#D97706", "#059669", "#DC2626", "#9333EA"],
+                  height: "180px",
+                  legend: true %>
+          <% else %>
+            <div class="text-center text-muted small py-4">No catch-ups logged yet.</div>
+          <% end %>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <%# Detail panels row %>
   <div class="row g-3 mb-4">
 

--- a/app/views/dashboard/timeline.html.erb
+++ b/app/views/dashboard/timeline.html.erb
@@ -58,7 +58,9 @@
             <div class="event-timeline-body">
               <div class="card">
                 <div class="card-body p-3">
-                  <div class="d-flex align-items-start justify-content-between gap-2">
+
+                  <%# Top row: icon + title + avatars %>
+                  <div class="d-flex align-items-start justify-content-between gap-2 mb-2">
                     <div class="d-flex align-items-center gap-2 min-w-0 flex-grow-1">
                       <span class="rounded-2 d-flex align-items-center justify-content-center flex-shrink-0"
                             style="width:32px; height:32px; background:<%= accent %>18; color:<%= accent %>; font-size:0.85rem;">
@@ -74,6 +76,9 @@
                           <span class="badge <%= medium_badge_class(event.medium) %>" style="font-size:0.65rem;"><%= event.medium.titleize %></span>
                           <span class="text-muted" style="font-size:0.75rem;">
                             <%= l event.occurred_at, format: :short %>
+                          </span>
+                          <span class="text-muted" style="font-size:0.7rem;">
+                            &middot; <%= time_ago_in_words(event.occurred_at) %> ago
                           </span>
                         </div>
                       </div>
@@ -100,6 +105,31 @@
                       </div>
                     <% end %>
                   </div>
+
+                  <%# Notes snippet %>
+                  <% if event.notes.present? %>
+                    <p class="text-muted mb-2 fst-italic"
+                       style="font-size:0.8rem; line-height:1.4; border-left:2px solid <%= accent %>40; padding-left:0.5rem;">
+                      <%= truncate(event.notes, length: 120) %>
+                    </p>
+                  <% end %>
+
+                  <%# Footer: days since per person + follow-up button %>
+                  <div class="d-flex align-items-center justify-content-between gap-2 mt-1">
+                    <div class="d-flex flex-wrap gap-2">
+                      <% event.people.first(3).each do |person| %>
+                        <% days_since = ((Time.current - event.occurred_at) / 1.day).round %>
+                        <span class="text-muted" style="font-size:0.72rem;">
+                          <i class="bi bi-clock me-1"></i><%= person.name.split.first %> &mdash; <%= days_since %> <%= "day".pluralize(days_since) %> ago
+                        </span>
+                      <% end %>
+                    </div>
+                    <% follow_up_path = event.people.one? ? new_event_path(person_id: event.people.first.id) : new_event_path %>
+                    <%= link_to follow_up_path, class: "btn btn-sm btn-outline-secondary flex-shrink-0", style: "font-size:0.75rem;" do %>
+                      <i class="bi bi-arrow-repeat me-1"></i>Log follow-up
+                    <% end %>
+                  </div>
+
                 </div>
               </div>
             </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -97,82 +97,59 @@
     <% end %>
   </div>
 
-  <% if @events.none? %>
-    <div class="text-center py-5 text-muted">
-      <i class="bi bi-calendar-x fs-2 d-block mb-2"></i>
-      No events in <%= @current_month.strftime("%B %Y") %>.
-    </div>
-  <% else %>
-    <div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-lg-5 g-2">
-      <% @events.each do |event| %>
-        <% accent = medium_colors[event.medium] || "#4338CA" %>
-        <% icon   = medium_icons[event.medium]  || "bi-calendar-check" %>
-        <div class="col" data-medium-filter-target="row" data-medium="<%= event.medium %>">
-          <div class="card position-relative" style="border-top: 3px solid <%= accent %>; aspect-ratio: 1;">
-            <div class="card-body d-flex flex-column p-3 h-100">
+  <%# Calendar grid %>
+  <% first_day   = @current_month.beginning_of_month %>
+  <% last_day    = @current_month.end_of_month %>
+  <% start_wday  = first_day.wday %>
+  <% trailing    = (7 - last_day.wday - 1) % 7 %>
 
-              <div class="d-flex align-items-start justify-content-between mb-2">
-                <span class="rounded-2 d-flex align-items-center justify-content-center flex-shrink-0"
-                      style="width:34px; height:34px; background:<%= accent %>18; color:<%= accent %>; font-size:0.95rem;">
-                  <i class="bi <%= icon %>"></i>
+  <div class="cal-grid">
+    <% %w[Sun Mon Tue Wed Thu Fri Sat].each do |d| %>
+      <div class="cal-day-header"><%= d %></div>
+    <% end %>
+
+    <% start_wday.times do %>
+      <div class="cal-day cal-day--empty"></div>
+    <% end %>
+
+    <% (first_day..last_day).each do |date| %>
+      <% day_events = @events_by_day[date] || [] %>
+      <% is_today   = date == Date.current %>
+      <div class="cal-day <%= 'cal-day--today' if is_today %>">
+        <span class="cal-day-num"><%= date.day %></span>
+        <% day_events.first(3).each do |event| %>
+          <% accent = medium_colors[event.medium] || "#4338CA" %>
+          <div class="cal-event" data-medium-filter-target="row" data-medium="<%= event.medium %>">
+            <span class="cal-event-dot" style="background:<%= accent %>;"></span>
+            <%= link_to truncate(event.display_title, length: 18), event_path(event),
+                  class: "cal-event-title text-decoration-none",
+                  style: "color:#{accent};" %>
+            <div class="cal-event-people">
+              <% event.people.first(2).each do |person| %>
+                <% p_color    = avatar_colors[person.name.bytes.sum % avatar_colors.length] %>
+                <% p_initials = person.name.split.first(2).map { |w| w[0].upcase }.join %>
+                <span class="avatar d-inline-flex"
+                      style="width:14px;height:14px;font-size:0.45rem;background:<%= p_color %>18;color:<%= p_color %>;">
+                  <%= p_initials %>
                 </span>
-                <div class="dropdown">
-                  <button class="btn btn-sm border-0 bg-transparent p-0 px-1" type="button"
-                          data-bs-toggle="dropdown" aria-expanded="false"
-                          aria-label="Options for <%= event.display_title %>">&#8943;</button>
-                  <ul class="dropdown-menu dropdown-menu-end shadow-sm">
-                    <li><%= link_to "View", event_path(event), class: "dropdown-item" %></li>
-                    <li><%= link_to "Edit", edit_event_path(event), class: "dropdown-item" %></li>
-                    <li><hr class="dropdown-divider"></li>
-                    <li>
-                      <%= button_to "Delete", event_path(event),
-                            method: :delete,
-                            form: { data: { turbo_confirm: "Remove this event?" } },
-                            class: "dropdown-item text-danger" %>
-                    </li>
-                  </ul>
-                </div>
-              </div>
-
-              <%= link_to event_path(event),
-                    class: "fw-semibold text-dark text-decoration-none d-block mb-1",
-                    style: "font-size:0.85rem; line-height:1.3; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden;" do %>
-                <%= highlight_match(event.display_title, params[:q]) %>
               <% end %>
-
-              <span class="badge <%= medium_badge_class(event.medium) %> align-self-start"><%= event.medium.titleize %></span>
-
-              <div class="flex-grow-1"></div>
-
-              <div class="d-flex align-items-center justify-content-between mt-2">
-                <div class="text-muted" style="font-size:0.72rem; line-height:1.2;">
-                  <div><%= event.occurred_at.strftime("%-d %b") %></div>
-                  <div><%= event.occurred_at.strftime("%a") %></div>
-                </div>
-                <div class="d-flex" style="gap:2px;">
-                  <% event.people.first(3).each do |person| %>
-                    <% p_color    = avatar_colors[person.name.bytes.sum % avatar_colors.length] %>
-                    <% p_initials = person.name.split.first(2).map { |w| w[0].upcase }.join %>
-                    <%= link_to person_path(person), class: "text-decoration-none", title: person.name do %>
-                      <span class="avatar d-inline-flex"
-                            style="width:20px; height:20px; font-size:0.55rem; background:<%= p_color %>18; color:<%= p_color %>;">
-                        <%= p_initials %>
-                      </span>
-                    <% end %>
-                  <% end %>
-                  <% if event.people.size > 3 %>
-                    <span class="avatar d-inline-flex"
-                          style="width:20px; height:20px; font-size:0.55rem; background:#F3F4F6; color:#6B7280;">
-                      +<%= event.people.size - 3 %>
-                    </span>
-                  <% end %>
-                </div>
-              </div>
-
             </div>
           </div>
-        </div>
-      <% end %>
+        <% end %>
+        <% if day_events.size > 3 %>
+          <span class="cal-more">+<%= day_events.size - 3 %> more</span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <% trailing.times do %>
+      <div class="cal-day cal-day--empty"></div>
+    <% end %>
+  </div>
+
+  <% if @events.none? %>
+    <div class="text-center py-4 text-muted small mt-3">
+      <i class="bi bi-calendar-x me-1"></i>No events in <%= @current_month.strftime("%B %Y") %>.
     </div>
   <% end %>
 </div>

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -119,7 +119,22 @@
         <span class="cal-day-num"><%= date.day %></span>
         <% day_events.first(3).each do |event| %>
           <% accent = medium_colors[event.medium] || "#4338CA" %>
-          <div class="cal-event" data-medium-filter-target="row" data-medium="<%= event.medium %>">
+          <% people_names = event.people.map(&:name).join(", ") %>
+          <% popover_html = "<div class='small'>" \
+               "<div class='fw-semibold mb-1'>#{h event.display_title}</div>" \
+               "<div class='text-muted mb-1'>#{h people_names}</div>" \
+               "<div class='mb-1'><span class='badge #{medium_badge_class(event.medium)}'>#{event.medium.titleize}</span> " \
+               "#{h event.occurred_at.strftime('%-I:%M %p · %b %-d')}</div>" \
+               "#{event.notes.present? ? "<div class='text-muted fst-italic'>#{h truncate(event.notes, length: 80)}</div>" : ''}" \
+               "</div>" %>
+          <div class="cal-event"
+               data-medium-filter-target="row"
+               data-medium="<%= event.medium %>"
+               data-bs-toggle="popover"
+               data-bs-trigger="hover focus"
+               data-bs-html="true"
+               data-bs-placement="top"
+               data-bs-content="<%= popover_html %>">
             <span class="cal-event-dot" style="background:<%= accent %>;"></span>
             <%= link_to truncate(event.display_title, length: 18), event_path(event),
                   class: "cal-event-title text-decoration-none",
@@ -137,7 +152,25 @@
           </div>
         <% end %>
         <% if day_events.size > 3 %>
-          <span class="cal-more">+<%= day_events.size - 3 %> more</span>
+          <% more_events = day_events.drop(3) %>
+          <% more_html = "<div class='small'>" +
+               more_events.map { |e|
+                 "<div class='d-flex align-items-center gap-1 mb-1'>" \
+                 "<span style='width:6px;height:6px;border-radius:50%;background:#{medium_colors[e.medium]};display:inline-block;flex-shrink:0;'></span>" \
+                 "<span>#{h e.display_title}</span>" \
+                 "<span class='text-muted ms-1'>· #{h e.people.map(&:name).join(', ')}</span>" \
+                 "</div>"
+               }.join +
+               "</div>" %>
+          <span class="cal-more"
+                style="cursor:pointer;"
+                data-bs-toggle="popover"
+                data-bs-trigger="hover focus"
+                data-bs-html="true"
+                data-bs-placement="top"
+                data-bs-content="<%= more_html %>">
+            +<%= more_events.size %> more
+          </span>
         <% end %>
       </div>
     <% end %>
@@ -153,3 +186,9 @@
     </div>
   <% end %>
 </div>
+
+<script>
+  document.querySelectorAll('[data-bs-toggle="popover"]').forEach(el => {
+    new bootstrap.Popover(el, { container: "body" });
+  });
+</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -56,6 +56,8 @@
       </div>
     </footer>
 
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartkick@5.0.1/dist/chartkick.js"></script>
     <script
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -35,6 +35,14 @@
 
   <div class="row g-3">
     <div class="col-md-6">
+      <%= f.label :birthday, class: "form-label" do %><i class="bi bi-cake2 me-1"></i>Birthday<% end %>
+      <%= f.date_field :birthday, class: "form-control" %>
+      <div class="form-text">Optional — used for birthday reminders.</div>
+    </div>
+  </div>
+
+  <div class="row g-3">
+    <div class="col-md-6">
       <%= f.label :preferred_start_hour, class: "form-label" do %><i class="bi bi-sun me-1"></i>Preferred start time<% end %>
       <%= f.select :preferred_start_hour,
             (0..23).map { |h| [Time.new(2000, 1, 1, h).strftime("%-I %p"), h] },

--- a/app/views/people/_person_row.html.erb
+++ b/app/views/people/_person_row.html.erb
@@ -20,6 +20,11 @@
               class: "text-decoration-none fw-medium text-dark d-block",
               data: { turbo_frame: "_top" } do %>
           <%= highlight_match(person.name, params[:q]) %>
+          <% if defined?(@upcoming_birthday_ids) && @upcoming_birthday_ids&.include?(person.id) %>
+            <% bday = person.birthday.change(year: Date.current.year); bday = bday.next_year if bday < Date.current %>
+            <span class="ms-1" title="Birthday <%= bday.strftime('%b %-d') %> (in <%= (bday - Date.current).to_i %> days)"
+                  style="font-size:0.75rem;">🎂</span>
+          <% end %>
         <% end %>
         <div class="d-flex align-items-center gap-1 flex-wrap mt-1">
           <%= link_to "mailto:#{person.email}", class: "text-muted text-decoration-none", style: "font-size:0.75rem;" do %>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -5,7 +5,7 @@
   arrow = @sort == col ? (@direction == "asc" ? " ▲" : " ▼") : ""
   active_class = @sort == col ? "active" : ""
   icon_tag = icon ? content_tag(:i, "", class: "bi #{icon} me-1") : nil
-  link_to safe_join([icon_tag, label, arrow].compact), root_path(sort: col, direction: next_dir),
+  link_to safe_join([icon_tag, label, arrow].compact), people_path(sort: col, direction: next_dir),
     class: "sort-link #{active_class} #{extra_class}"
 end %>
 
@@ -57,7 +57,7 @@ end %>
   </div>
 <% end %>
 
-<%= form_with url: root_path, method: :get,
+<%= form_with url: people_path, method: :get,
       data: { controller: "auto-submit", turbo_frame: "people-table" },
       class: "mb-3" do %>
   <label for="people-search-input" class="visually-hidden">Search people</label>
@@ -82,7 +82,7 @@ end %>
 
 <% tag_colors = %w[#0D9488 #7C3AED #D97706 #E11D48 #2563EB #059669 #9333EA #B45309] %>
 <div class="mb-3 d-flex flex-wrap gap-2 align-items-center">
-  <%= link_to root_path(favorites: @favorites_filter ? nil : "1", sort: @sort, direction: @direction),
+  <%= link_to people_path(favorites: @favorites_filter ? nil : "1", sort: @sort, direction: @direction),
         class: "btn btn-sm #{@favorites_filter ? 'btn-warning' : 'btn-outline-secondary'}" do %>
     <i class="bi bi-star<%= '-fill' if @favorites_filter %> me-1"></i>
     <%= @favorites_filter ? "Showing favorites" : "Favorites only" %>
@@ -90,7 +90,7 @@ end %>
   <% @all_tags.each_with_index do |tag, i| %>
     <% active = @tag_filter&.id == tag.id %>
     <% color = tag_colors[i % tag_colors.length] %>
-    <%= link_to root_path(tag_id: active ? nil : tag.id, sort: @sort, direction: @direction, q: params[:q]),
+    <%= link_to people_path(tag_id: active ? nil : tag.id, sort: @sort, direction: @direction, q: params[:q]),
           class: "btn btn-sm #{'btn-outline-secondary' unless active}",
           style: (active ? "background:#{color}; border-color:#{color}; color:#fff;" : nil) do %>
       <i class="bi bi-tag me-1"></i><%= tag.name %>

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -34,6 +34,17 @@
           <%= mail_to @person.email, class: "text-muted" %>
           <span class="mx-1">&middot;</span>
           <i class="bi bi-globe2 me-1"></i><%= @person.timezone %>
+          <% if @person.birthday.present? %>
+            <span class="mx-1">&middot;</span>
+            <i class="bi bi-cake2 me-1"></i><%= @person.birthday.strftime("%B %-d") %>
+            <% days = (@person.birthday.change(year: Date.current.year) - Date.current).to_i %>
+            <% days = (@person.birthday.change(year: Date.current.year + 1) - Date.current).to_i if days < 0 %>
+            <% if days == 0 %>
+              <span class="badge bg-warning text-dark">🎂 Today!</span>
+            <% elsif days <= 14 %>
+              <span class="badge" style="background:#FEF3C7;color:#92400E;">in <%= days %> days</span>
+            <% end %>
+          <% end %>
         </p>
         <div class="d-flex gap-2 flex-wrap">
           <span class="stat-chip">
@@ -86,12 +97,21 @@
         <% end %>
         <%= form_with url: snooze_person_path(@person), method: :patch,
               class: "d-inline-flex align-items-center gap-1", data: { turbo: true } do |f| %>
+          <label class="text-muted small me-1" style="white-space:nowrap;">Snooze until:</label>
           <%= f.date_field :snoozed_until, value: @person.snoozed_until,
                 class: "form-control form-control-sm",
-                style: "width: 150px;",
+                style: "width: 140px;",
                 min: Date.current.to_s %>
           <%= f.button class: "btn btn-sm #{@person.snoozed? ? 'btn-outline-secondary' : 'btn-outline-info'}" do %>
             <i class="bi bi-bell-slash me-1"></i><%= @person.snoozed? ? "Update" : "Snooze" %>
+          <% end %>
+        <% end %>
+        <%= form_with model: @person,
+              class: "d-inline-flex align-items-center gap-1", data: { turbo: true } do |f| %>
+          <label class="text-muted small me-1" style="white-space:nowrap;"><i class="bi bi-cake2"></i> Birthday:</label>
+          <%= f.date_field :birthday, class: "form-control form-control-sm", style: "width: 140px;" %>
+          <%= f.button class: "btn btn-sm btn-outline-secondary" do %>
+            Save
           <% end %>
         <% end %>
         <%= link_to "Edit", edit_person_path(@person), class: "btn btn-outline-primary btn-sm" %>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -13,8 +13,12 @@
       <% if authenticated? %>
         <ul class="navbar-nav me-auto">
           <li class="nav-item">
-            <%= link_to "People", root_path,
-                  class: "nav-link #{"active fw-semibold" if request.path == root_path || request.path.start_with?(people_path)}" %>
+            <%= link_to "Dashboard", dashboard_path,
+                  class: "nav-link #{"active fw-semibold" if request.path == root_path || request.path == dashboard_path}" %>
+          </li>
+          <li class="nav-item">
+            <%= link_to "People", people_path,
+                  class: "nav-link #{"active fw-semibold" if request.path.start_with?(people_path)}" %>
           </li>
           <li class="nav-item">
             <%= link_to "Events", events_path,
@@ -23,10 +27,6 @@
           <li class="nav-item">
             <%= link_to "Timeline", timeline_path,
                   class: "nav-link #{"active fw-semibold" if request.path == timeline_path}" %>
-          </li>
-          <li class="nav-item">
-            <%= link_to "Dashboard", dashboard_path,
-                  class: "nav-link #{"active fw-semibold" if request.path == dashboard_path}" %>
           </li>
         </ul>
       <% end %>

--- a/config/initializers/groupdate.rb
+++ b/config/initializers/groupdate.rb
@@ -1,0 +1,1 @@
+require "groupdate"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,5 +40,5 @@ Rails.application.routes.draw do
   resources :events
   resources :tags, only: %i[index update destroy]
 
-  root "people#index"
+  root "dashboard#index"
 end

--- a/db/migrate/20260526034622_add_birthday_to_people.rb
+++ b/db/migrate/20260526034622_add_birthday_to_people.rb
@@ -1,0 +1,5 @@
+class AddBirthdayToPeople < ActiveRecord::Migration[8.1]
+  def change
+    add_column :people, :birthday, :date
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_25_184311) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_26_034622) do
   create_table "event_participants", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "event_id", null: false
@@ -45,6 +45,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_25_184311) do
   end
 
   create_table "people", force: :cascade do |t|
+    t.date "birthday"
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.boolean "favorite", default: false, null: false

--- a/docs/team-features-summary.md
+++ b/docs/team-features-summary.md
@@ -5,11 +5,12 @@
 - **People index UI** — full table layout with color-hashed initials avatars, soft pill status badges (Overdue / Due Soon / On Track), sortable columns with Turbo Frame swaps, real-time search with debounce, tag filter chips, and favorites filter.
 - **Overdue alerts** — highlighted panel at the top of the People index surfacing contacts past their catch-up deadline with direct "Log Event" links.
 - **Person show page** — restructured into a card layout with contact info, streak/days-until-due stats, event history, timezone conversion (contact's local time + preferred hours converted to the user's timezone), and AI reconnect message in one view.
-- **Events index UI** — per-medium color badges, medium filter bar, and a month-picker for browsing event history by calendar month.
+- **Events index UI** — per-medium color badges, medium filter bar, and a full monthly calendar grid view where events are placed on their actual days; hovering any event shows a popover with full title, people, medium, time, and notes snippet.
 - **Log Event form UX** — participant search bar, person pre-fill when navigating from a contact, notes character counter, and 12-hour time select dropdowns for preferred hours.
-- **Relationship health dashboard** — collapsible summary panel categorizing all contacts into Overdue / Slipping / On Track with stat cards (this month's catch-ups, streak, avg frequency, top contacts).
+- **Relationship health dashboard** — collapsible summary panel categorizing all contacts into Overdue / Slipping / On Track with stat cards (this month's catch-ups, streak, avg frequency, top contacts); catch-ups-per-month bar chart and by-medium pie chart (Chartkick + Groupdate); upcoming birthdays alert showing contacts with birthdays in the next 30 days; set as the app's default landing page.
 - **AI reconnect messages** — integrated OpenRouter (Gemma 4) to generate a personalized reach-out suggestion on the Person show page, with one-click clipboard copy.
 - **Contact import** — CSV and vCard (.vcf) upload flow with smart header normalization (Google Contacts and Apple Contacts formats), duplicate detection, and a results summary.
+- **Birthday tracking** — birthday field on contacts with inline save on the show page; 🎂 indicator next to names on the People list for anyone with a birthday in the next 30 days; birthday badge on the show page counting down days.
 - **Login & signup UI** — redesigned as a split-panel layout with brand panel on the left and form on the right.
 - **PWA & mobile** — web manifest, service worker with offline cache, and offline fallback page; app is installable via "Add to Home Screen" on iOS and Android; custom app logo and icon.
 - **Tags** — tags management page (rename, delete, person count), inline toggle-tag on People.


### PR DESCRIPTION
 hover popover listing the hidden events.
  - Dashboard charts — added a catch-ups-per-month bar chart (last 6 months) and a by-medium
  pie chart using Chartkick + Groupdate. Dashboard is now the default landing page after
  login.
  - Birthday tracking — new birthday date field on Person (migration included). Inline save
  directly on the person show page. 🎂 indicator next to names on the People list for anyone
  with a birthday in the next 30 days. Upcoming birthdays alert banner on the dashboard.
  - Timeline enrichment — each event card now shows notes snippet (italic, left-bordered),
  time-ago label, and a "Log follow-up" button pre-filled with the contact.