### PR TITLE
Bump jwt/faraday for CVEs + fix .env.example callback path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,12 +4,12 @@
 # ── Google Calendar OAuth 2.0 ────────────────────────────────────────────────
 # Create credentials at https://console.cloud.google.com/apis/credentials
 # Application type: Web application
-# Authorized redirect URI: http://localhost:3000/auth/google/callback  (dev)
-#                          https://<your-app>.herokuapp.com/auth/google/callback  (prod)
+# Authorized redirect URI: http://localhost:3000/google/oauth/callback  (dev)
+#                          https://<your-app>.herokuapp.com/google/oauth/callback  (prod)
 
 GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your-client-secret
-GOOGLE_REDIRECT_URI=http://localhost:3000/auth/google/callback
+GOOGLE_REDIRECT_URI=http://localhost:3000/google/oauth/callback
 
 # ── OpenRouter AI (reconnect message suggestions) ───────────────────────────
 # Get a free API key at https://openrouter.ai/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
       railties (>= 6.1.0)
     faker (3.8.0)
       i18n (>= 1.8.11, < 2)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -182,7 +182,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.19.4)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -500,7 +500,7 @@ CHECKSUMS
   factory_bot (6.5.6) sha256=12beb373214dccc086a7a63763d6718c49769d5606f0501e0a4442676917e077
   factory_bot_rails (6.5.1) sha256=d3cc4851eae4dea8a665ec4a4516895045e710554d2b5ac9e68b94d351bc6d68
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
-  faraday (2.14.1) sha256=a43cceedc1e39d188f4d2cdd360a8aaa6a11da0c407052e426ba8d3fb42ef61c
+  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
@@ -517,7 +517,7 @@ CHECKSUMS
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
-  jwt (3.1.2) sha256=af6991f19a6bb4060d618d9add7a66f0eeb005ac0bc017cd01f63b42e122d535
+  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203


### PR DESCRIPTION
Repo-wide housekeeping off `main` — clears the `scan_ruby` check that's currently red on **every** open PR (and on `main` itself), and fixes a doc bug in the env example.

## 1. Security: bump two transitive gems
`bundler-audit` (the `scan_ruby` CI step) started failing after the advisory DB updated on 2026-05-26, flagging:

| Gem | Was | Now | Advisory |
|-----|-----|-----|----------|
| `jwt` | 3.1.2 | **3.2.0** | CVE-2026-45363 (**High**) — empty-key HMAC bypass |
| `faraday` | 2.14.1 | **2.14.2** | CVE-2026-33637 — host-scoping bypass |

Both are transitive (pulled in by the Google auth stack), so this is a conservative `bundle update` — **`Gemfile` is unchanged**. `bundler-audit` now reports **no vulnerabilities**; the full suite stays green.

## 2. Fix `.env.example` OAuth callback path (#114)
The example documented `…/auth/google/callback`, but the real route is `…/google/oauth/callback` (`config/routes.rb` → `Google::OauthController`). Following the stale value gives a `redirect_uri_mismatch` during local Google setup. `README.md` was already correct — this just aligns the example file.

## Verification
- `bundle exec bundler-audit check --update` → **No vulnerabilities found**
- `rspec` → 120 examples, 0 failures · `rubocop` clean · `erb_lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
