### PR TITLE
Match contacts to users: both-calendar scheduling + sign-up-aware invites (#89, #90)

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -101,15 +101,46 @@ class EventsController < ApplicationController
     to_h,   _to_m  = parse_time_param(params.dig(:event, :preferred_to))
     to_h = [to_h, from_h + 1].max
 
-    if current_user.google_calendar_connected?
-      GoogleCalendarService.new(current_user)
-                           .find_earliest_slot(
-                             window_days:   window_days,
-                             from_hour:     from_h,
-                             to_hour:       to_h,
-                             slot_duration: duration_min.minutes
-                           )
-    end || default_slot(window_days, from_h, from_m)
+    busy = collect_busy_intervals(window_days)
+    slot = if busy
+      GoogleCalendarService.earliest_free_slot(
+        busy:          busy,
+        window_days:   window_days,
+        from_hour:     from_h,
+        to_hour:       to_h,
+        slot_duration: duration_min.minutes
+      )
+    end
+
+    slot || default_slot(window_days, from_h, from_m)
+  end
+
+  # Merged free/busy from the organizer's calendar plus every invited Person who
+  # is also a registered user with Google Calendar connected (issue #90). Returns
+  # nil when no calendars are available, so scheduling falls back to default_slot
+  # exactly as before.
+  def collect_busy_intervals(window_days)
+    calendar_users = []
+    calendar_users << current_user if current_user.google_calendar_connected?
+    calendar_users.concat(matched_invitee_users)
+    return nil if calendar_users.empty?
+
+    calendar_users.flat_map do |u|
+      GoogleCalendarService.new(u).busy_intervals(window_days: window_days)
+    end
+  end
+
+  # Registered users (other than the organizer) behind the invited People,
+  # matched by email, who have connected Google Calendar. Each is queried with
+  # its own credential, so only free/busy windows are read — never event detail.
+  def matched_invitee_users
+    emails = @event.people.filter_map { |p| p.email&.strip&.downcase }
+    return [] if emails.empty?
+
+    User.where(email: emails)
+        .where.not(id: current_user.id)
+        .includes(:google_credential)
+        .select(&:google_calendar_connected?)
   end
 
   def parse_time_param(val)

--- a/app/mailers/event_mailer.rb
+++ b/app/mailers/event_mailer.rb
@@ -5,6 +5,7 @@ class EventMailer < ApplicationMailer
     @event          = event
     @person         = person
     @organizer      = organizer
+    @registered     = person.registered?
     @slot_time      = event.occurred_at.in_time_zone(person.timezone.presence || CHICAGO_TZ)
     @duration_label = format_duration(event.duration_minutes || 60)
 

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -83,6 +83,20 @@ class Person < ApplicationRecord
     count
   end
 
+  # The registered User account (if any) that shares this contact's email.
+  # User emails are normalized to lowercase, so we match case-insensitively.
+  # Used to check an invitee's calendar availability and to tailor invites.
+  def matched_user
+    return @matched_user if defined?(@matched_user)
+
+    @matched_user = email.present? ? User.find_by(email: email.strip.downcase) : nil
+  end
+
+  # True when this contact corresponds to a registered Serendipity user.
+  def registered?
+    matched_user.present?
+  end
+
   private
 
   def preferred_window_ordered

--- a/app/services/google_calendar_service.rb
+++ b/app/services/google_calendar_service.rb
@@ -40,10 +40,10 @@ class GoogleCalendarService
     []
   end
 
-  # Finds the earliest 15-min-aligned free 30-min slot within the next window_days days,
-  # restricted to hours [from_hour, to_hour) in the user's timezone. Returns a UTC Time,
-  # or nil if no slot found.
-  def find_earliest_slot(window_days:, from_hour:, to_hour:, slot_duration: 60.minutes, buffer: 15.minutes)
+  # Returns busy [start, end] Time pairs for the user's primary calendar over
+  # the next window_days days. Returns [] if the free/busy query fails, so a
+  # caller merging several users' calendars degrades gracefully per-user.
+  def busy_intervals(window_days:)
     service    = build_service
     now        = Time.current
     window_end = now + window_days.days
@@ -54,11 +54,23 @@ class GoogleCalendarService
       items:    [{ id: "primary" }]
     )
     response = service.query_freebusy(request)
-    cal  = response.calendars["primary"] || response.calendars.values.first
-    busy = (cal && !cal.errors&.any?) ? cal.busy.map { |s| [s.start, s.end] } : []
+    cal = response.calendars["primary"] || response.calendars.values.first
+    (cal && !cal.errors&.any?) ? cal.busy.map { |s| [s.start, s.end] } : []
+  rescue StandardError => e
+    Rails.logger.warn("busy_intervals failed: #{e.message}")
+    []
+  end
 
-    cursor = now.ceil(15.minutes)
-    tz     = Time.zone
+  # Finds the earliest free slot_duration slot within the next window_days days,
+  # restricted to hours [from_hour, to_hour) in tz, that avoids every interval in
+  # busy (each a [start, end] pair) plus a buffer on either side. Pure function:
+  # the caller passes the merged busy intervals from however many calendars it
+  # wants considered (e.g. organizer + registered invitees). Returns a Time or nil.
+  def self.earliest_free_slot(busy:, window_days:, from_hour:, to_hour:,
+                              slot_duration: 60.minutes, buffer: 15.minutes,
+                              tz: Time.zone, now: Time.current)
+    window_end = now + window_days.days
+    cursor     = now.ceil(15.minutes)
 
     while cursor + slot_duration <= window_end
       local = cursor.in_time_zone(tz)
@@ -70,9 +82,6 @@ class GoogleCalendarService
       cursor += 15.minutes
     end
 
-    nil
-  rescue StandardError => e
-    Rails.logger.warn("find_earliest_slot failed: #{e.message}")
     nil
   end
 

--- a/app/views/event_mailer/calendar_invite.html.erb
+++ b/app/views/event_mailer/calendar_invite.html.erb
@@ -17,9 +17,13 @@
 </div>
 
 <div class="footer">
-  <p>
-    Does this time not work for you?
-    <%= link_to "Join Serendipity", signup_url %> and connect your Google Calendar for more precise scheduling.
-  </p>
+  <% if @registered %>
+    <p>We checked your calendar and picked a time that looked free for you. Open the attachment to confirm.</p>
+  <% else %>
+    <p>
+      Does this time not work for you?
+      <%= link_to "Join Serendipity", signup_url %> and connect your Google Calendar so future invites land on a time you're free.
+    </p>
+  <% end %>
   <p style="margin-top: 8px;">This invitation was sent via Serendipity on behalf of <%= @organizer.email %>.</p>
 </div>

--- a/app/views/event_mailer/calendar_invite.text.erb
+++ b/app/views/event_mailer/calendar_invite.text.erb
@@ -10,4 +10,8 @@ Hi <%= @person.name.split.first %>,
 Open the attached .ics file to accept or decline this invitation.
 
 ---
-Does this time not work for you? Join Serendipity at <%= signup_url %> and connect your Google Calendar for more precise scheduling.
+<% if @registered -%>
+We checked your calendar and picked a time that looked free for you. Open the attached .ics to confirm.
+<% else -%>
+Does this time not work for you? Join Serendipity at <%= signup_url %> and connect your Google Calendar so future invites land on a time you're free.
+<% end -%>

--- a/spec/mailers/event_mailer_spec.rb
+++ b/spec/mailers/event_mailer_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe EventMailer, type: :mailer do
+  let(:organizer) { create(:user, email: "organizer@example.com") }
+  let(:event) do
+    create(:event, user: organizer, title: "Coffee", medium: "coffee",
+                   occurred_at: 1.day.from_now, people: [person])
+  end
+
+  describe "#calendar_invite" do
+    context "when the invitee is not a registered user" do
+      let(:person) { create(:person, user: organizer, email: "stranger@example.com") }
+
+      it "encourages them to sign up" do
+        mail = described_class.calendar_invite(event, person, organizer)
+        expect(mail.body.encoded).to include("Join Serendipity")
+      end
+    end
+
+    context "when the invitee is already a registered user" do
+      let!(:invitee) { create(:user, email: "member@example.com") }
+      let(:person)   { create(:person, user: organizer, email: "member@example.com") }
+
+      it "does not show the sign-up nudge" do
+        mail = described_class.calendar_invite(event, person, organizer)
+        expect(mail.body.encoded).not_to include("Join Serendipity")
+      end
+    end
+  end
+end

--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -86,4 +86,25 @@ RSpec.describe Person, type: :model do
       expect(person.days_until_due).to be > 0
     end
   end
+
+  describe "#matched_user and #registered?" do
+    it "returns the registered User that shares this person's email" do
+      invitee = create(:user, email: "bob@example.com")
+      person  = create(:person, email: "bob@example.com")
+      expect(person.matched_user).to eq(invitee)
+      expect(person).to be_registered
+    end
+
+    it "matches case-insensitively" do
+      invitee = create(:user, email: "carol@example.com")
+      person  = create(:person, email: "Carol@Example.com")
+      expect(person.matched_user).to eq(invitee)
+    end
+
+    it "returns nil and is not registered when no user shares the email" do
+      person = create(:person, email: "nobody@example.com")
+      expect(person.matched_user).to be_nil
+      expect(person).not_to be_registered
+    end
+  end
 end

--- a/spec/requests/events_spec.rb
+++ b/spec/requests/events_spec.rb
@@ -69,6 +69,44 @@ RSpec.describe "Events", type: :request do
     end
   end
 
+  describe "POST /events scheduling against both calendars (#90)" do
+    let(:invitee) { create(:user, email: "inv@example.com") }
+    let(:invited_person) { create(:person, user: user, email: "inv@example.com") }
+
+    it "consults a registered, Google-connected invitee's calendar" do
+      create(:google_credential, user: invitee) # organizer is NOT connected here
+      fake = instance_double(GoogleCalendarService, busy_intervals: [])
+      expect(GoogleCalendarService).to receive(:new).with(invitee).and_return(fake)
+
+      post events_path, params: { event: valid_attrs.merge(person_ids: [invited_person.id]) }
+
+      expect(fake).to have_received(:busy_intervals)
+    end
+
+    it "consults both the organizer's and the invitee's calendars when both are connected" do
+      create(:google_credential, user: user)
+      create(:google_credential, user: invitee)
+      organizer_service = instance_double(GoogleCalendarService, busy_intervals: [], push_event: nil)
+      invitee_service   = instance_double(GoogleCalendarService, busy_intervals: [])
+      allow(GoogleCalendarService).to receive(:new).with(user).and_return(organizer_service)
+      allow(GoogleCalendarService).to receive(:new).with(invitee).and_return(invitee_service)
+
+      post events_path, params: { event: valid_attrs.merge(person_ids: [invited_person.id]) }
+
+      expect(organizer_service).to have_received(:busy_intervals)
+      expect(invitee_service).to have_received(:busy_intervals)
+    end
+
+    it "does not consult an invited contact who is not a registered user" do
+      stranger = create(:person, user: user, email: "stranger@example.com")
+      expect(GoogleCalendarService).not_to receive(:new)
+
+      post events_path, params: { event: valid_attrs.merge(person_ids: [stranger.id]) }
+
+      expect(response).to redirect_to(event_path(Event.last))
+    end
+  end
+
   describe "PATCH /events/:id" do
     it "updates attributes and participants" do
       event   = create(:event, title: "Old", people: [person_a], user: user)

--- a/spec/services/google_calendar_service_spec.rb
+++ b/spec/services/google_calendar_service_spec.rb
@@ -117,6 +117,64 @@ RSpec.describe GoogleCalendarService, type: :service do
     end
   end
 
+  describe ".earliest_free_slot" do
+    let(:tz)  { ActiveSupport::TimeZone["UTC"] }
+    let(:now) { tz.local(2026, 5, 1, 8, 0, 0) } # Fri 08:00 UTC
+
+    it "returns the first slot inside preferred hours when nothing is busy" do
+      slot = described_class.earliest_free_slot(
+        busy: [], window_days: 1, from_hour: 9, to_hour: 17, now: now, tz: tz
+      )
+      expect(slot).to eq(tz.local(2026, 5, 1, 9, 0, 0))
+    end
+
+    it "skips a busy block, respecting the 15-minute buffer" do
+      busy = [[tz.local(2026, 5, 1, 9, 0, 0), tz.local(2026, 5, 1, 10, 0, 0)]]
+      slot = described_class.earliest_free_slot(
+        busy: busy, window_days: 1, from_hour: 9, to_hour: 17, now: now, tz: tz
+      )
+      expect(slot).to eq(tz.local(2026, 5, 1, 10, 15, 0))
+    end
+
+    it "returns nil when every preferred-hour slot is busy" do
+      busy = [[tz.local(2026, 5, 1, 0, 0, 0), tz.local(2026, 5, 2, 0, 0, 0)]]
+      slot = described_class.earliest_free_slot(
+        busy: busy, window_days: 1, from_hour: 9, to_hour: 10, now: now, tz: tz
+      )
+      expect(slot).to be_nil
+    end
+  end
+
+  describe "#busy_intervals" do
+    let(:calendar_service_double) { instance_double(Google::Apis::CalendarV3::CalendarService) }
+    let(:auth_double)             { instance_double(Signet::OAuth2::Client) }
+    let(:t1) { Time.utc(2026, 5, 1, 14, 0, 0) }
+    let(:t2) { Time.utc(2026, 5, 1, 15, 0, 0) }
+
+    before do
+      allow(Signet::OAuth2::Client).to receive(:new).and_return(auth_double)
+      allow(auth_double).to receive(:refresh!)
+      allow(auth_double).to receive(:access_token).and_return("new-access-token")
+      allow(auth_double).to receive(:expires_at).and_return(1.hour.from_now.to_i)
+      allow(Google::Apis::CalendarV3::CalendarService).to receive(:new).and_return(calendar_service_double)
+      allow(calendar_service_double).to receive(:authorization=)
+      credential.update!(expires_at: 1.hour.from_now)
+    end
+
+    it "returns busy [start, end] pairs from the primary calendar" do
+      cal      = double("calendar", errors: [], busy: [double(start: t1, end: t2)])
+      response = double("freebusy", calendars: { "primary" => cal })
+      allow(calendar_service_double).to receive(:query_freebusy).and_return(response)
+
+      expect(service.busy_intervals(window_days: 7)).to eq([[t1, t2]])
+    end
+
+    it "returns [] when the free/busy query raises" do
+      allow(calendar_service_double).to receive(:query_freebusy).and_raise(StandardError)
+      expect(service.busy_intervals(window_days: 7)).to eq([])
+    end
+  end
+
   private
 
   def stub_env_vars


### PR DESCRIPTION
Closes #89. Closes #90.

**Re-targets the feature work to `main`.** #136 was accidentally merged into the `serendipity-rebrand-logo` branch instead of `main` (its base wasn't retargeted in time), so the rebrand (#135) reached `main` but this feature did not. This PR puts it on `main` cleanly — it's the same feature commit cherry-picked onto current `main`, so the diff is **feature-only** (no rebrand/dep noise).

Links a `Person` (contact) to a `User` (account) by email, then:

- **#90 — both-calendar scheduling.** Scheduling now merges free/busy from the organizer **and** every invited contact who is a registered user with Google connected, then picks the earliest slot free for everyone. Each invitee is queried with their own credential (free/busy only — never event detail). Falls back to the previous default-slot behavior when no calendars are connected.
- **#89 — sign-up-aware invites.** Unregistered invitees get a nudge to join Serendipity + connect Google; registered invitees get a "we checked your calendar" note.

## Key changes
- `Person#matched_user` / `#registered?` — case-insensitive email lookup (no migration).
- `GoogleCalendarService` — `busy_intervals(window_days:)` (API) + pure `self.earliest_free_slot(...)` (testable).
- `EventsController#find_scheduled_slot` — merges busy intervals across organizer + matched invitees.

## Verification
- `rspec` → **133 examples, 0 failures** (incl. new model/service/mailer/request specs, Google stubbed) · `rubocop` clean · `erb_lint` clean.
- Built on current `main` (post #137), so `scan_ruby` is green too.

## Limitation (for #90)
Only matched users who connected Google are checked; cross-timezone preferred-hours intersection is future work. Live Google path not exercised locally (OAuth redirect URI pending — #114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
