### PR TITLE
Refresh seed production guard, README, and schema doc (#23, #24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@
 - RuboCop added to CI pipeline as a `lint` job; deploy gate now requires lint to pass
 - Configured `.rubocop.yml` to allow `%i[ ]` / `%w[ ]` bracket style produced by Rails generators
 
+### Security
+- `db/seeds.rb` now `abort`s (exits non-zero) if run against `production` (closes #23, #24). The script is destructive (`User.delete_all`, etc.) and creates demo accounts with hardcoded passwords — both intentional for local dev and unsafe for prod.
+- `README.md` no longer instructs running `heroku run rails db:seed`; real users should sign up through the UI on the live deployment.
+- Added `docs/schema.md` — a human-readable mirror of `db/schema.rb` documenting tables, columns, indexes, and relationships.
+
 ## [v1.2.0] — 2026-05-10 — Pagination & Large Dataset Support
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -83,12 +83,17 @@ First-time setup from the project root:
 ```bash
 heroku create stay-in-touch-<team-suffix>        # pick a unique suffix
 heroku addons:create heroku-postgresql:essential-0
-git push heroku claude/m0-rails-foundation:main   # or main once merged
-heroku run rails db:seed
+git push heroku main
 heroku open
 ```
 
 The `Procfile` runs `rails db:migrate` automatically in the release phase, so subsequent deploys just need `git push heroku main`.
+
+> **Do not run `rails db:seed` against production.** The seed file is
+> development-only — it deletes every row in the People, Events, Tags, and
+> Users tables and creates demo accounts whose passwords are committed to this
+> repo. The script will refuse to run (and exit non-zero) if
+> `RAILS_ENV=production`. Sign up a real account through the UI instead.
 
 ## Terminology
 
@@ -110,7 +115,7 @@ design walkthrough, asset locations, and how to regenerate `public/icon.png`.
 - `app/controllers/` - Thin controllers with strong params and the seven REST actions.
 - `app/views/people/` and `app/views/events/` - Bootstrap 5 index, show, new, edit, and `_form` partials.
 - `app/views/shared/` - Navbar and flash partials used across the app.
-- `db/seeds.rb` - 12 people + 15 events, idempotent.
+- `db/seeds.rb` - Faker-generated demo data (a demo user plus extra users, each with people and events); re-runnable, development-only.
 - `spec/` - RSpec model and request specs.
 - `claude-initial-files/` - Original Python prototype and product vision for Serendipity (historical reference only).
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,8 +1,13 @@
-# Idempotent seed script for development only.
-# NEVER run db:seed in production — it wipes all data.
+# Development/test-only seed script. Re-runnable: wipes every row in the tables
+# below and re-creates demo users plus Faker-generated example data.
+#
+# Refuse to run against production: the script is destructive (User.delete_all
+# would wipe every real account) and creates demo accounts whose passwords are
+# committed to this public repo. Both behaviors are intentional for local dev
+# and unsafe for prod. See GitHub issues #23 and #24.
 if Rails.env.production?
-  puts "Skipping seeds in production."
-  return
+  abort "db/seeds.rb is development-only — refusing to run in #{Rails.env}. " \
+        "If you really need to seed prod, do it from the rails console with explicit data."
 end
 
 require "faker"

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -1,0 +1,182 @@
+# Database Schema
+
+Authoritative source: [`db/schema.rb`](../db/schema.rb) (schema version
+`2026_05_26_034622`). This document is a human-readable mirror — regenerate it
+if you add migrations. Constraints marked *(model)* are enforced in the Active
+Record model rather than the database.
+
+## Tables & Attributes
+
+### `users`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `email` | string | not null, unique (case-insensitive), email format *(model)* | |
+| `password_digest` | string | not null (`has_secure_password`) | |
+| `reset_token` | string | nullable, indexed | |
+| `reset_token_expires_at` | datetime | nullable | |
+| `timezone` | string | not null, default `"America/Chicago"`, IANA *(model)* | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Passwords must be >10 chars with an upper, lower, digit, and special character *(model)*. On create, a user is seeded the default tags `Work`, `Family`, `Friends`.
+
+### `sessions`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null, indexed | **FK → users.id** |
+| `expires_at` | datetime | nullable, indexed | |
+| `ip_address` | string | nullable | |
+| `user_agent` | string | nullable | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Session lifetime is 30 days; a session is `expired?` when `expires_at` is nil or in the past.
+
+### `people`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null, indexed | **FK → users.id** |
+| `name` | string | not null, ≤255 chars *(model)* | |
+| `email` | string | not null, unique per `user_id` (case-insensitive), email format *(model)* | |
+| `timezone` | string | not null, default `"America/Chicago"`, IANA *(model)* | |
+| `preferred_start_hour` | integer | not null, default 9, range 0–23 *(model)* | |
+| `preferred_end_hour` | integer | not null, default 21, range 0–23 *(model)* | |
+| `frequency_weeks` | decimal(5,2) | not null, default 4.0, in `(0, 520]` *(model)* | |
+| `notes` | text | nullable, ≤5000 chars *(model)* | |
+| `favorite` | boolean | not null, default false; indexed with `user_id` | |
+| `birthday` | date | nullable | |
+| `snoozed_until` | date | nullable | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Model rule: `preferred_start_hour ≤ preferred_end_hour`. A person is `snoozed?` while `snoozed_until` is today or later.
+
+### `events`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null, indexed | **FK → users.id** |
+| `occurred_at` | datetime | not null, indexed | |
+| `medium` | string | not null, one of `call`/`coffee`/`text`/`video`/`in_person`/`other` *(model)* | |
+| `duration_minutes` | integer | not null, default 60 | |
+| `title` | string | nullable, ≤255 chars *(model)*; falls back to `medium` for display | |
+| `notes` | text | nullable, ≤5000 chars *(model)* | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Model rule: every event must have ≥1 participant.
+
+### `event_participants`  *(join: people ↔ events)*
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `person_id` | integer | not null, indexed | **FK → people.id** |
+| `event_id` | integer | not null, indexed | **FK → events.id** |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Composite unique index on `(person_id, event_id)`.
+
+### `google_credentials`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null, unique index | **FK → users.id** |
+| `access_token` | string | not null | |
+| `refresh_token` | string | not null | |
+| `expires_at` | datetime | not null | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+One row per user (`has_one`). Stores Google Calendar OAuth tokens; `expired?` when `expires_at` has passed.
+
+### `tags`
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `user_id` | integer | not null, indexed | **FK → users.id** |
+| `name` | string | required, ≤50 chars, unique per `user_id` (case-insensitive) *(model)* | |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Composite unique index on `(user_id, name)`. New users start with `Work`, `Family`, `Friends`.
+
+### `person_tags`  *(join: people ↔ tags)*
+| Column | Type | Constraints | Key |
+|---|---|---|---|
+| `id` | integer | not null, auto | **PK** |
+| `person_id` | integer | not null, indexed | **FK → people.id** |
+| `tag_id` | integer | not null, indexed | **FK → tags.id** |
+| `created_at` | datetime | not null | |
+| `updated_at` | datetime | not null | |
+
+Composite unique index on `(person_id, tag_id)`.
+
+---
+
+## ER Diagram (cardinality)
+
+```
+                          ┌──────────────────────────┐
+                          │           users          │
+                          │──────────────────────────│
+                          │ PK  id                    │
+                          │     email (unique)        │
+                          │     password_digest       │
+                          │     reset_token           │
+                          │     timezone              │
+                          └──┬────┬────┬────┬─────┬───┘
+            1                │ 1  │ 1  │ 1  │ 1   │ 1
+       ┌─────────────────────┘    │    │    │     └──────────────┐
+       │ M                  ┌──────┘    │    └──────┐ M           │ 1
+       ▼                    │ M         │ M         ▼             ▼
+┌──────────────┐           ▼           ▼      ┌──────────┐ ┌────────────────────┐
+│   sessions   │   ┌──────────────┐ ┌────────┐│   tags   │ │ google_credentials │
+│──────────────│   │    people    │ │ events ││──────────│ │────────────────────│
+│ PK id        │   │──────────────│ │────────││ PK id    │ │ PK id              │
+│ FK user_id   │   │ PK id        │ │ PK id  ││ FK user  │ │ FK user_id (unique)│
+│    expires_at│   │ FK user_id   │ │ FK user││    name  │ │    access_token    │
+│    ip/ua     │   │    name      │ │ occured│└────┬─────┘ │    refresh_token   │
+└──────────────┘   │    email     │ │ medium │     │ M     │    expires_at      │
+                   │    favorite  │ │ durat. │     │       └────────────────────┘
+                   │    birthday  │ │ title  │     │
+                   │    snoozed   │ └───┬────┘     │
+                   └──┬────────┬──┘     │ M        │
+                    M │        │ M      │          │
+                      │        ▼        ▼          ▼
+                      │   ┌─────────────────┐ ┌──────────────────┐
+                      │   │ event_participants│ │   person_tags    │
+                      │   │ (M:M people↔events)│ │ (M:M people↔tags)│
+                      │   │──────────────────│ │──────────────────│
+                      │   │ PK id            │ │ PK id            │
+                      └──▶│ FK person_id     │ │ FK person_id ◀───┘
+                          │ FK event_id      │ │ FK tag_id        │
+                          │ uniq(person,evt) │ │ uniq(person,tag) │
+                          └──────────────────┘ └──────────────────┘
+```
+
+## Relationships (cardinality summary)
+
+| Parent | Child | Cardinality | Notes |
+|---|---|---|---|
+| `users` | `sessions` | **one-to-many** | `dependent: :destroy` |
+| `users` | `people` | **one-to-many** | `dependent: :destroy` |
+| `users` | `events` | **one-to-many** | `dependent: :destroy` |
+| `users` | `tags` | **one-to-many** | `dependent: :destroy` |
+| `users` | `google_credentials` | **one-to-one** | `has_one`, `dependent: :destroy` |
+| `people` | `event_participants` | **one-to-many** | `dependent: :destroy` |
+| `events` | `event_participants` | **one-to-many** | `dependent: :destroy` |
+| `people` ↔ `events` | (via `event_participants`) | **many-to-many** | unique on the pair |
+| `people` | `person_tags` | **one-to-many** | `dependent: :destroy` |
+| `tags` | `person_tags` | **one-to-many** | `dependent: :destroy` |
+| `people` ↔ `tags` | (via `person_tags`) | **many-to-many** | unique on the pair |
+
+Notable rules:
+
+- Each user's `people.email` and `tags.name` are unique within that user's scope, not globally.
+- Every `event` must have ≥1 participant *(model validation)*.
+- `preferred_start_hour ≤ preferred_end_hour` *(model validation)*.
+- A `person` is matched to a registered `user` by case-insensitive email (no FK) to check calendar availability and tailor invites.


### PR DESCRIPTION
Refreshes the stale `fix/seed-production-guard` branch (PR #25, which was 154 commits behind `main`). Re-applies the still-valuable changes on top of current `main` rather than rebasing, and regenerates the schema doc that had gone out of date.

**Supersedes #25** — that PR can be closed once this merges.

## Changes
- **`db/seeds.rb`** — Replaced `main`'s silent `puts … return` production check with a loud `abort` (exits non-zero). The seed script is destructive (`User.delete_all`, etc.) and creates demo accounts with passwords committed to the repo, so failing loudly is preferable to a silent skip. Comment updated to describe the current Faker/multi-user seed.
- **`README.md`** — Removed the dangerous `heroku run rails db:seed` deploy step (and a stale `claude/m0-rails-foundation` branch reference), added a do-not-seed-prod warning, and fixed the outdated "12 people + 15 events" seed description.
- **`CHANGELOG.md`** — Added a `### Security` entry under the existing `[Unreleased]` section.
- **`docs/schema.md`** — Regenerated against the current 8-table schema. The version in #25 documented only 5 tables (missing `google_credentials`, `tags`, `person_tags`, plus 7 columns). Now includes all tables, indexes, foreign keys, model-level validations, and a refreshed ER diagram.

## Verification
- `ruby -c db/seeds.rb` → Syntax OK
- `rubocop db/seeds.rb` → no offenses
- All 8 `create_table`s in `db/schema.rb` are covered by `docs/schema.md`
- gitleaks + commit-msg hooks pass

Closes #23, closes #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
