### PR TITLE
M2 hardening: scale seed, CSV limits, duration validation, edit-form UX

### DIFF
--- a/app/assets/stylesheets/app.css
+++ b/app/assets/stylesheets/app.css
@@ -590,6 +590,22 @@ textarea:focus-visible,
   color: #fff;
 }
 
+/* ── Unsaved-changes (dirty form) Save-button highlight ──── */
+form.is-dirty .btn-primary {
+  animation: dirty-save-pulse 1.8s ease-out infinite;
+}
+@keyframes dirty-save-pulse {
+  0%   { box-shadow: 0 0 0 0 rgba(67, 56, 202, 0.45); }
+  70%  { box-shadow: 0 0 0 8px rgba(67, 56, 202, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(67, 56, 202, 0); }
+}
+@media (prefers-reduced-motion: reduce) {
+  form.is-dirty .btn-primary {
+    animation: none;
+    box-shadow: 0 0 0 3px rgba(67, 56, 202, 0.35);
+  }
+}
+
 /* ── Turbo Frame modal overlay ──────────────────────────── */
 turbo-frame#quick-log-modal.turbo-modal {
   display: none;

--- a/app/assets/stylesheets/app.css
+++ b/app/assets/stylesheets/app.css
@@ -606,6 +606,18 @@ form.is-dirty .btn-primary {
   }
 }
 
+/* Keep the unsaved-changes banner pinned to the top while scrolling the form. */
+.unsaved-banner {
+  position: sticky;
+  top: 0;
+  z-index: 90; /* above scrolling form fields; below the mobile topbar (100) */
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+@media (max-width: 991.98px) {
+  /* Sit just below the sticky mobile topbar instead of behind it. */
+  .unsaved-banner { top: 52px; }
+}
+
 /* ── Turbo Frame modal overlay ──────────────────────────── */
 turbo-frame#quick-log-modal.turbo-modal {
   display: none;

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -55,8 +55,19 @@ class PeopleController < ApplicationController
     return unless request.post?
 
     file = params[:csv_file]
-    unless file
-      flash.now[:alert] = "Please select a CSV file."
+    unless file.respond_to?(:read)
+      flash.now[:alert] = "Please select a CSV or vCard file."
+      return render :import, status: :unprocessable_content
+    end
+
+    unless CsvImportService.allowed_file?(file)
+      flash.now[:alert] = "Unsupported file type. Please upload a .csv or .vcf file."
+      return render :import, status: :unprocessable_content
+    end
+
+    if file.size > CsvImportService::MAX_FILE_SIZE
+      max_mb = CsvImportService::MAX_FILE_SIZE / 1.megabyte
+      flash.now[:alert] = "That file is too large (max #{max_mb} MB)."
       return render :import, status: :unprocessable_content
     end
 

--- a/app/javascript/controllers/dirty_form_controller.js
+++ b/app/javascript/controllers/dirty_form_controller.js
@@ -1,0 +1,57 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Makes unsaved edits obvious. Snapshots the form on connect; whenever the
+// current values differ from that snapshot it reveals an "unsaved changes"
+// banner, highlights the Save button, and guards against leaving the page
+// (closing the tab via beforeunload, or in-app Turbo navigation like Cancel).
+// Reverting every field back to its original value clears the warning.
+//
+// Wire-up (people/_form.html.erb):
+//   <%= form_with …, data: {
+//         controller: "dirty-form",
+//         action: "input->dirty-form#check change->dirty-form#check " +
+//                 "submit->dirty-form#markSaved" } %>
+//     <div data-dirty-form-target="indicator" hidden> … </div>
+export default class extends Controller {
+  static targets = ["indicator"]
+
+  connect() {
+    this.clean = this.#snapshot()
+    this.dirty = false
+
+    this.beforeUnload = (event) => {
+      if (!this.dirty) return
+      event.preventDefault()
+      event.returnValue = "" // required for the native prompt in some browsers
+    }
+    this.beforeVisit = (event) => {
+      if (this.dirty && !window.confirm("You have unsaved changes. Leave without saving?")) {
+        event.preventDefault()
+      }
+    }
+
+    window.addEventListener("beforeunload", this.beforeUnload)
+    document.addEventListener("turbo:before-visit", this.beforeVisit)
+  }
+
+  disconnect() {
+    window.removeEventListener("beforeunload", this.beforeUnload)
+    document.removeEventListener("turbo:before-visit", this.beforeVisit)
+  }
+
+  check() {
+    this.dirty = this.#snapshot() !== this.clean
+    this.element.classList.toggle("is-dirty", this.dirty)
+    if (this.hasIndicatorTarget) this.indicatorTarget.hidden = !this.dirty
+  }
+
+  // The form is being submitted, so the pending edits are about to be saved —
+  // drop the guard so the submission/redirect isn't blocked.
+  markSaved() {
+    this.dirty = false
+  }
+
+  #snapshot() {
+    return new URLSearchParams(new FormData(this.element)).toString()
+  }
+}

--- a/app/javascript/controllers/tag_toggle_controller.js
+++ b/app/javascript/controllers/tag_toggle_controller.js
@@ -1,0 +1,24 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Colors a tag pill in/out the instant its (hidden) checkbox is toggled.
+// The server still renders the initial `.active` state on page load; this keeps
+// the pill in sync as the user clicks, instead of only updating after a reload.
+//
+// Wire-up (people/_form.html.erb):
+//   <div data-controller="tag-toggle" data-action="change->tag-toggle#toggle"> … </div>
+export default class extends Controller {
+  connect() {
+    this.element
+      .querySelectorAll('input[type="checkbox"]')
+      .forEach((checkbox) => this.#paint(checkbox))
+  }
+
+  toggle(event) {
+    if (event.target.type === "checkbox") this.#paint(event.target)
+  }
+
+  #paint(checkbox) {
+    const label = checkbox.closest(".tag-checkbox-label")
+    if (label) label.classList.toggle("active", checkbox.checked)
+  }
+}

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -20,6 +20,11 @@ class Event < ApplicationRecord
   validates :medium, presence: true, inclusion: { in: MEDIA }
   validates :title, length: { maximum: 255 }, allow_blank: true
   validates :notes, length: { maximum: 5000 }, allow_blank: true
+  # Server-side guard for the form's duration picker (15–120 min). The DB
+  # column is `default: 60, null: false`, so this never rejects normal input;
+  # it exists to reject crafted/out-of-range values (e.g. negative or absurd).
+  validates :duration_minutes,
+            numericality: { only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 1440 }
   validate  :must_have_at_least_one_person
 
   scope :recent, -> { order(occurred_at: :desc) }

--- a/app/services/csv_import_service.rb
+++ b/app/services/csv_import_service.rb
@@ -11,6 +11,21 @@ class CsvImportService
     timezone:        %w[timezone time_zone tz]
   }.freeze
 
+  # Upload guards (the controller rejects oversized/wrong-type files before we
+  # ever read them; MAX_ROWS is the in-parser backstop against a small file
+  # that still expands into a huge number of rows).
+  MAX_FILE_SIZE       = 2.megabytes
+  MAX_ROWS            = 5_000
+  ALLOWED_EXTENSIONS  = %w[.csv .vcf].freeze
+
+  # True when the uploaded file's name ends in an accepted extension. Extension
+  # rather than browser-supplied content_type because the latter is unreliable
+  # and easily spoofed; the parsers below are also defensive about content.
+  def self.allowed_file?(file)
+    name = file.try(:original_filename).to_s.downcase
+    ALLOWED_EXTENSIONS.any? { |ext| name.end_with?(ext) }
+  end
+
   Result = Data.define(:created, :skipped, :errors)
 
   def initialize(file, user)
@@ -22,6 +37,14 @@ class CsvImportService
     content  = read_content
     filename = @file.respond_to?(:original_filename) ? @file.original_filename.to_s : ""
     rows     = filename.end_with?(".vcf") || vcf_content?(content) ? parse_vcf(content) : parse_csv(content)
+
+    if rows.size > MAX_ROWS
+      return Result.new(
+        created: 0,
+        skipped: [],
+        errors:  [ "File has #{rows.size} entries; the maximum is #{MAX_ROWS}. Please split it into smaller files." ]
+      )
+    end
 
     created = 0
     skipped = []

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -2,7 +2,7 @@
       data: { controller: "dirty-form",
               action: "input->dirty-form#check change->dirty-form#check submit->dirty-form#markSaved" } do |f| %>
   <div data-dirty-form-target="indicator" role="status"
-       class="alert alert-warning d-flex align-items-center gap-2 py-2 mb-0" hidden>
+       class="unsaved-banner alert alert-warning d-flex align-items-center gap-2 py-2 mb-0" hidden>
     <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
     <span>You have unsaved changes — don't forget to <strong>Save</strong>.</span>
   </div>

--- a/app/views/people/_form.html.erb
+++ b/app/views/people/_form.html.erb
@@ -1,4 +1,12 @@
-<%= form_with model: person, class: "vstack gap-3" do |f| %>
+<%= form_with model: person, class: "vstack gap-3",
+      data: { controller: "dirty-form",
+              action: "input->dirty-form#check change->dirty-form#check submit->dirty-form#markSaved" } do |f| %>
+  <div data-dirty-form-target="indicator" role="status"
+       class="alert alert-warning d-flex align-items-center gap-2 py-2 mb-0" hidden>
+    <i class="bi bi-exclamation-triangle-fill" aria-hidden="true"></i>
+    <span>You have unsaved changes — don't forget to <strong>Save</strong>.</span>
+  </div>
+
   <% if person.errors.any? %>
     <div class="alert alert-danger">
       <strong><%= pluralize(person.errors.count, "error") %> prevented this person from being saved:</strong>
@@ -70,7 +78,8 @@
   <div>
     <label class="form-label fw-semibold"><i class="bi bi-tag me-1"></i>Tags</label>
     <% if @all_tags.any? %>
-      <div class="d-flex flex-wrap gap-2 mb-2">
+      <div class="d-flex flex-wrap gap-2 mb-2"
+           data-controller="tag-toggle" data-action="change->tag-toggle#toggle">
         <% @all_tags.each do |tag| %>
           <% checked = person.tags.include?(tag) %>
           <label class="tag-checkbox-label <%= 'active' if checked %>">

--- a/app/views/people/import.html.erb
+++ b/app/views/people/import.html.erb
@@ -62,7 +62,11 @@
                  class="form-control"
                  accept=".csv,.vcf,text/csv,text/vcard"
                  required>
-          <div class="form-text">CSV or vCard (.vcf) files accepted.</div>
+          <div class="form-text">
+            CSV or vCard (.vcf) files accepted —
+            up to <%= CsvImportService::MAX_FILE_SIZE / 1.megabyte %> MB
+            and <%= number_with_delimiter(CsvImportService::MAX_ROWS) %> contacts.
+          </div>
         </div>
         <div class="card-footer bg-transparent d-flex justify-content-end">
           <%= f.submit "Import", class: "btn btn-primary" %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,6 +24,28 @@ TIMEZONES = %w[America/Chicago America/New_York America/Los_Angeles America/Denv
 MEDIUMS   = Event::MEDIA.freeze
 FREQ_OPTS = [1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0].freeze
 
+# Realistic filler so the seeded activity timeline reads like real catch-ups
+# rather than lorem ipsum.
+EVENT_TITLES = [
+  "Birthday call", "Quick check-in", "Long overdue chat", "Coffee downtown",
+  "Lunch meetup", "Weekend hangout", "Congrats call", "Just checking in",
+  "Holiday catch-up", "Welcome-home dinner", "Catching up", "Game night"
+].freeze
+EVENT_NOTES = [
+  "Great to reconnect after so long.", "Talked about the new job.",
+  "Caught up on family news.", "Planned a trip for next month.",
+  "Shared updates about work and kids.", "Reminisced about old times.",
+  "Quick chat — promised to meet up soon.", "Lots of laughs, felt good.",
+  "Talked through some big life decisions.", "Made plans for the holidays."
+].freeze
+PERSON_NOTES = [
+  "Met at a conference in 2023.", "College roommate.",
+  "Former coworker, now in Seattle.", "Loves hiking and photography.",
+  "Has two kids, recently moved.", "Met through mutual friends.",
+  "Always up for a coffee.", "Neighbor from the old apartment.",
+  "Friend from grad school.", "We go way back — high school."
+].freeze
+
 # ── Clear existing data ───────────────────────────────────────────────────────
 # Order matters: delete_all does not fire association callbacks, so children
 # (and FK-referencing rows like tags) must go before their parents or the
@@ -64,7 +86,7 @@ def seed_people_and_events(user, people_count:, events_count:)
       frequency_weeks:      FREQ_OPTS.sample,
       favorite:             rand < 0.15,
       birthday:             (rand < 0.3 ? Faker::Date.birthday(min_age: 18, max_age: 75) : nil),
-      notes:                Faker::Lorem.sentence(word_count: 6)
+      notes:                (rand < 0.8 ? PERSON_NOTES.sample : nil)
     )
   end
   Faker::Name.unique.clear
@@ -75,8 +97,8 @@ def seed_people_and_events(user, people_count:, events_count:)
     user.events.create!(
       occurred_at: Faker::Time.between(from: 2.years.ago, to: Time.current),
       medium:      MEDIUMS.sample,
-      title:       rand < 0.6 ? Faker::Lorem.words(number: rand(2..4)).join(" ").capitalize : nil,
-      notes:       rand < 0.5 ? Faker::Lorem.sentence(word_count: 8) : nil,
+      title:       rand < 0.6 ? EVENT_TITLES.sample : nil,
+      notes:       rand < 0.5 ? EVENT_NOTES.sample : nil,
       people:      participants
     )
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,18 +6,30 @@ if Rails.env.production?
 end
 
 require "faker"
+require "bcrypt"
 
+# ── Scale knobs ───────────────────────────────────────────────────────────────
+# Defaults are sized to make pagination and performance issues visible during
+# development (1000+ users, 1000+ people/events). Override any of them to seed a
+# lighter or heavier dataset, e.g.  SEED_USERS=50 bin/rails db:seed
+TOTAL_USERS  = Integer(ENV.fetch("SEED_USERS",        "1000"))  # incl. demo + rich users
+RICH_USERS   = Integer(ENV.fetch("SEED_RICH_USERS",   "9"))     # users with full people+events
+DEMO_PEOPLE  = Integer(ENV.fetch("SEED_DEMO_PEOPLE",  "200"))   # 8 pages at 25/page
+DEMO_EVENTS  = Integer(ENV.fetch("SEED_DEMO_EVENTS",  "800"))
+RICH_PEOPLE  = Integer(ENV.fetch("SEED_RICH_PEOPLE",  "40"))
+RICH_EVENTS  = Integer(ENV.fetch("SEED_RICH_EVENTS",  "80"))
+
+TIMEZONES = %w[America/Chicago America/New_York America/Los_Angeles America/Denver
+               Europe/London Europe/Paris Asia/Tokyo Asia/Singapore].freeze
+MEDIUMS   = Event::MEDIA.freeze
+FREQ_OPTS = [1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0].freeze
+
+# ── Clear existing data ───────────────────────────────────────────────────────
+# Order matters: delete_all does not fire association callbacks, so children
+# (and FK-referencing rows like tags) must go before their parents or the
+# foreign keys will reject the delete.
 puts "Clearing existing data..."
-EventParticipant.delete_all
-Event.delete_all
-Person.delete_all
-Session.delete_all
-User.delete_all
-
-TIMEZONES  = %w[America/Chicago America/New_York America/Los_Angeles America/Denver
-                Europe/London Europe/Paris Asia/Tokyo Asia/Singapore].freeze
-MEDIUMS    = Event::MEDIA.freeze
-FREQ_OPTS  = [1.0, 1.5, 2.0, 3.0, 4.0, 6.0, 8.0, 12.0].freeze
+[ EventParticipant, Event, PersonTag, Tag, GoogleCredential, Session, Person, User ].each(&:delete_all)
 
 # ── Demo user (known credentials for easy dev login) ──────────────────────────
 seed_email    = ENV.fetch("SEED_USER_EMAIL",    "demo@example.com")
@@ -30,17 +42,15 @@ demo_user = User.create!(
   password_confirmation: seed_password
 )
 
-# ── Extra users (to test multi-user isolation) ────────────────────────────────
-puts "Creating extra users..."
-extra_users = 9.times.map do |i|
+# ── Rich users (full people + events, to test multi-user isolation) ───────────
+puts "Creating #{RICH_USERS} rich users..."
+rich_users = RICH_USERS.times.map do |i|
   User.create!(
     email: "user#{i + 2}@example.com",
     password: "Demo1!password",
     password_confirmation: "Demo1!password"
   )
 end
-
-all_users = [demo_user] + extra_users
 
 # ── Helper: seed people + events for one user ─────────────────────────────────
 def seed_people_and_events(user, people_count:, events_count:)
@@ -49,9 +59,11 @@ def seed_people_and_events(user, people_count:, events_count:)
       name:                 Faker::Name.unique.name,
       email:                Faker::Internet.unique.email,
       timezone:             TIMEZONES.sample,
-      preferred_start_hour: [8, 9, 10].sample,
-      preferred_end_hour:   [20, 21, 22].sample,
+      preferred_start_hour: [ 8, 9, 10 ].sample,
+      preferred_end_hour:   [ 20, 21, 22 ].sample,
       frequency_weeks:      FREQ_OPTS.sample,
+      favorite:             rand < 0.15,
+      birthday:             (rand < 0.3 ? Faker::Date.birthday(min_age: 18, max_age: 75) : nil),
       notes:                Faker::Lorem.sentence(word_count: 6)
     )
   end
@@ -70,13 +82,38 @@ def seed_people_and_events(user, people_count:, events_count:)
   end
 end
 
-puts "Seeding demo user with 100 people and 300 events..."
-seed_people_and_events(demo_user, people_count: 100, events_count: 300)
+# One transaction around all the create! work — on SQLite this turns thousands
+# of per-row commits into a single commit and cuts seed time dramatically.
+ActiveRecord::Base.transaction do
+  puts "Seeding demo user with #{DEMO_PEOPLE} people and #{DEMO_EVENTS} events..."
+  seed_people_and_events(demo_user, people_count: DEMO_PEOPLE, events_count: DEMO_EVENTS)
 
-puts "Seeding extra users (50 people, 150 events each)..."
-extra_users.each_with_index do |user, i|
-  seed_people_and_events(user, people_count: 50, events_count: 150)
-  print "  user #{i + 2} done\n"
+  puts "Seeding rich users (#{RICH_PEOPLE} people, #{RICH_EVENTS} events each)..."
+  rich_users.each_with_index do |user, i|
+    seed_people_and_events(user, people_count: RICH_PEOPLE, events_count: RICH_EVENTS)
+    print "  user #{i + 2} done\n"
+  end
+end
+
+# ── Bulk "scale" users (to populate the users table to 1000+) ─────────────────
+# These exist purely to exercise table scale and cross-tenant isolation, so we
+# skip the per-record cost of bcrypt + the default-tags callback: every row
+# shares one precomputed password digest and is written in a single insert_all.
+bulk_count = TOTAL_USERS - 1 - rich_users.size
+if bulk_count.positive?
+  puts "Bulk-inserting #{bulk_count} scale users (shared password digest)..."
+  shared_digest = BCrypt::Password.create("Demo1!password")
+  now = Time.current
+  rows = (1..bulk_count).map do |n|
+    {
+      email:           "scale_user_#{n}@example.com",
+      password_digest: shared_digest,
+      timezone:        TIMEZONES.sample,
+      created_at:      now,
+      updated_at:      now
+    }
+  end
+  rows.each_slice(1_000) { |slice| User.insert_all(slice) }
 end
 
 puts ""
@@ -84,3 +121,4 @@ puts "Seed complete:"
 puts "  #{User.count} users (login: #{seed_email} / #{seed_password})"
 puts "  #{Person.count} people"
 puts "  #{Event.count} events"
+puts "  #{Tag.count} tags, #{EventParticipant.count} event participants"

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -30,6 +30,22 @@ RSpec.describe Event, type: :model do
       event  = build(:event, people: people)
       expect(event).to be_valid
     end
+
+    describe "duration_minutes" do
+      it "accepts every value the form's picker offers" do
+        [ 15, 30, 45, 60, 90, 120 ].each do |mins|
+          expect(build(:event, duration_minutes: mins)).to be_valid
+        end
+      end
+
+      it "rejects zero, negative, and absurdly large values" do
+        [ 0, -5, 5000 ].each do |bad|
+          event = build(:event, duration_minutes: bad)
+          expect(event).not_to be_valid
+          expect(event.errors[:duration_minutes]).to be_present
+        end
+      end
+    end
   end
 
   describe ".recent" do

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -1,4 +1,5 @@
 require "rails_helper"
+require "tempfile"
 
 RSpec.describe "People", type: :request do
   let(:user) { create(:user) }
@@ -186,6 +187,48 @@ RSpec.describe "People", type: :request do
       fav = create(:person, user: user, favorite: true,  name: "Zara Aaa")
       get people_path
       expect(response.body.index(fav.name)).to be < response.body.index("Aaron Zzz")
+    end
+  end
+
+  describe "POST /people/import" do
+    def csv_upload(content, filename: "contacts.csv")
+      file = Tempfile.new([ "upload", File.extname(filename) ])
+      file.binmode
+      file.write(content)
+      file.rewind
+      Rack::Test::UploadedFile.new(file.path, nil, original_filename: filename)
+    end
+
+    it "imports people from a valid CSV" do
+      csv = "name,email\nJane Smith,jane@example.com\n"
+      expect {
+        post import_people_path, params: { csv_file: csv_upload(csv) }
+      }.to change(user.people, :count).by(1)
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Import complete")
+    end
+
+    it "rejects an unsupported file type without importing" do
+      expect {
+        post import_people_path, params: { csv_file: csv_upload("whatever", filename: "notes.txt") }
+      }.not_to change(Person, :count)
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Unsupported file type")
+    end
+
+    it "rejects a file over the size limit without importing" do
+      stub_const("CsvImportService::MAX_FILE_SIZE", 10)
+      expect {
+        post import_people_path, params: { csv_file: csv_upload("name,email\nJane,jane@example.com\n") }
+      }.not_to change(Person, :count)
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("too large")
+    end
+
+    it "rejects a missing file" do
+      post import_people_path
+      expect(response).to have_http_status(:unprocessable_content)
+      expect(response.body).to include("Please select")
     end
   end
 

--- a/spec/requests/people_spec.rb
+++ b/spec/requests/people_spec.rb
@@ -124,6 +124,14 @@ RSpec.describe "People", type: :request do
       get edit_person_path(person)
       expect(response).to have_http_status(:ok)
     end
+
+    it "wires up the dirty-form and tag-toggle Stimulus controllers" do
+      person = create(:person, user: user) # user gets default tags on create
+      get edit_person_path(person)
+      expect(response.body).to include('data-controller="dirty-form"')
+      expect(response.body).to include("You have unsaved changes")
+      expect(response.body).to include('data-controller="tag-toggle"')
+    end
   end
 
   describe "PATCH /people/:id" do

--- a/spec/services/csv_import_service_spec.rb
+++ b/spec/services/csv_import_service_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe CsvImportService do
+  let(:user) { create(:user) }
+
+  # Minimal stand-in for an uploaded file: the service only needs #read and
+  # #original_filename.
+  def upload(content, filename: "contacts.csv")
+    instance_double("ActionDispatch::Http::UploadedFile", read: content, original_filename: filename)
+  end
+
+  describe ".allowed_file?" do
+    it "accepts .csv and .vcf (any case)" do
+      expect(described_class.allowed_file?(upload("", filename: "a.csv"))).to be true
+      expect(described_class.allowed_file?(upload("", filename: "a.CSV"))).to be true
+      expect(described_class.allowed_file?(upload("", filename: "a.vcf"))).to be true
+    end
+
+    it "rejects other extensions and a missing filename" do
+      expect(described_class.allowed_file?(upload("", filename: "a.txt"))).to be false
+      expect(described_class.allowed_file?(upload("", filename: "a.exe"))).to be false
+      expect(described_class.allowed_file?(upload("", filename: ""))).to be false
+    end
+  end
+
+  describe "#call" do
+    it "creates people from a simple CSV" do
+      csv = "name,email,frequency_weeks\nJane Smith,jane@example.com,2\nJohn Doe,john@example.com,4\n"
+      result = nil
+      expect { result = described_class.new(upload(csv), user).call }
+        .to change(user.people, :count).by(2)
+      expect(result.created).to eq(2)
+      expect(result.errors).to be_empty
+    end
+
+    it "refuses files with more rows than MAX_ROWS and imports nothing" do
+      stub_const("CsvImportService::MAX_ROWS", 2)
+      rows = (1..3).map { |n| "Person #{n},p#{n}@example.com" }.join("\n")
+      csv  = "name,email\n#{rows}\n"
+
+      result = nil
+      expect { result = described_class.new(upload(csv), user).call }
+        .not_to change(Person, :count)
+      expect(result.created).to eq(0)
+      expect(result.errors.first).to match(/maximum is 2/)
+    end
+  end
+end


### PR DESCRIPTION
M2 chores + per-member contributions, batched on a branch off the post-rebrand `main`.

## Functionality / data scale
- **Seed scaled to 1,000 users / 1,520 events** so pagination and performance are visible in dev. Bulk "scale" users use a shared bcrypt digest + `insert_all` (skip per-row bcrypt and the default-tags callback) so the seed runs in ~23s; the demo + rich users keep full `create!` with associations. Heavy inserts wrapped in one transaction (fast on SQLite). Delete order fixed to clear tags/person_tags before users so re-seeding no longer FK-fails.
- Seed text is realistic catch-up phrasing instead of lorem ipsum.

## Input sanitization (server-side validation + upload limits)
- `CsvImportService`: `MAX_FILE_SIZE` (2 MB), `MAX_ROWS` (5,000), and `.allowed_file?` extension allowlist; over-long files get a friendly error with no partial import.
- `PeopleController#import`: rejects wrong file type and oversized files *before* reading them; import view shows the limits.
- `Event#duration_minutes`: server-side numericality validation (1..1440) backing the DB default and the form's 15-120 picker.

## JavaScript-driven UX (person new/edit form)
- `tag_toggle_controller`: tag pills color in/out the instant their hidden checkbox toggles (was only reflecting server-rendered state after reload).
- `dirty_form_controller`: snapshots the form and, when any field differs, shows a **sticky** "unsaved changes" banner, pulses the Save button (reduced-motion safe), and guards against leaving via `beforeunload` (tab close) and `turbo:before-visit` (Cancel / in-app nav). Reverting all fields clears the warning; submitting drops the guard.

## Tests
- Event duration bounds; `CsvImportService` (allowed_file?, row cap, happy path); request specs for import type/size/missing-file rejection; request spec asserting the edit form renders the Stimulus wiring.
- Full suite green: **144 examples, 0 failures**. JS click-behavior verified manually in-browser (no JS test harness in this project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
