### PR TITLE
Surface failed matchmaking rounds as :error rows

### DIFF
--- a/app/jobs/run_matchmaking_job.rb
+++ b/app/jobs/run_matchmaking_job.rb
@@ -24,7 +24,17 @@ class RunMatchmakingJob < ApplicationJob
       begin
         Matchmaking::RoundOrchestratorService.new(requester).call
       rescue StandardError => e
-        Rails.logger.warn("Matchmaking failed for user #{requester.id}: #{e.message}")
+        Rails.logger.error("RunMatchmakingJob: requester=#{requester.id} raised #{e.class}: #{e.message}")
+        # Surface the failure on the user's Matches page so they don't just see
+        # nothing happen. The orchestrator already records :error rows for its
+        # own controlled-nil paths; this catches whatever it missed.
+        MeetingProposal.create!(
+          requester:                  requester,
+          recipient:                  nil,
+          status:                     :error,
+          decision_reason:            "Matchmaking failed unexpectedly (#{e.class}). See Heroku logs for details.",
+          requester_profile_snapshot: requester.meeting_interests
+        )
       end
     end
   end

--- a/app/models/meeting_proposal.rb
+++ b/app/models/meeting_proposal.rb
@@ -4,20 +4,25 @@
 # if either user later edits their interests.
 #
 # Schema (see db/schema.rb for the authoritative version):
-#   requester_id / recipient_id  :integer not null  (both FK -> users)
-#   status                       :integer not null  (enum below)
-#   pitch / decision_reason      :text    nullable
-#   *_profile_snapshot           :text    nullable
-#   meeting_at                   :datetime nullable (set when a calendar event is made)
-#   calendar_event_id/_link      :string  nullable
-#   calendar_created             :boolean not null  default false
+#   requester_id  :integer not null  (FK -> users)
+#   recipient_id  :integer nullable  (FK -> users; nil only on :error proposals
+#                                     where the round died before a target was picked)
+#   status        :integer not null  (enum below)
+#   pitch / decision_reason   :text    nullable
+#   *_profile_snapshot        :text    nullable
+#   meeting_at                :datetime nullable (set when a calendar event is made)
+#   calendar_event_id/_link   :string  nullable
+#   calendar_created          :boolean not null  default false
 class MeetingProposal < ApplicationRecord
   # Don't pitch the same ordered pair again within this window (anti-spam).
   RECENCY_WINDOW = 30.days
 
   belongs_to :requester, class_name: "User"
-  belongs_to :recipient, class_name: "User"
+  belongs_to :recipient, class_name: "User", optional: true
 
+  # :error rows record a round that couldn't complete (model rate-limited,
+  # unparseable AI output, no candidates, etc.) so the failure shows up on the
+  # Matches page instead of vanishing.
   enum :status, { pending: 0, accepted: 1, declined: 2, error: 3 }
 
   validate :requester_and_recipient_differ
@@ -29,20 +34,25 @@ class MeetingProposal < ApplicationRecord
   scope :recent, -> { order(created_at: :desc) }
 
   # Has this exact (requester -> recipient) direction been proposed recently?
+  # Errors don't count — they shouldn't gate a real retry.
   def self.recently_proposed_between?(requester, recipient)
     where(requester_id: requester.id, recipient_id: recipient.id)
+      .where.not(status: :error)
       .where(created_at: RECENCY_WINDOW.ago..)
       .exists?
   end
 
-  # The party who is not the given user.
+  # The party who is not the given user. Nil if this is an error row that never
+  # picked a recipient.
   def other_party(user)
-    user.id == requester_id ? recipient : requester
+    return recipient if user.id == requester_id
+    requester
   end
 
   private
 
   def requester_and_recipient_differ
+    return if recipient_id.nil?
     errors.add(:recipient_id, "can't be the same as the requester") if requester_id == recipient_id
   end
 end

--- a/app/services/matchmaking/rate_limited_chat.rb
+++ b/app/services/matchmaking/rate_limited_chat.rb
@@ -20,7 +20,13 @@ module Matchmaking
         yield
       rescue Faraday::TooManyRequestsError => e
         attempt += 1
-        raise if attempt >= MAX_ATTEMPTS
+        if attempt >= MAX_ATTEMPTS
+          Rails.logger.error(
+            "Matchmaking: OpenRouter 429 retries exhausted after " \
+            "#{MAX_ATTEMPTS} attempts; re-raising"
+          )
+          raise
+        end
 
         delay = retry_after(e) || [ BASE_DELAY * (2**(attempt - 1)), MAX_DELAY ].min
         Rails.logger.info(

--- a/app/services/matchmaking/round_orchestrator_service.rb
+++ b/app/services/matchmaking/round_orchestrator_service.rb
@@ -16,17 +16,37 @@ module Matchmaking
     end
 
     def call
-      return nil if ENV["OPENROUTER_API_KEY"].blank?
-      return nil unless @requester.matchmaking_ready?
+      # Configuration / opt-in gates: log but don't record an :error proposal —
+      # these aren't per-round failures, they're "this round can't run." The
+      # controller already flashes the API-key case, and the Matches page
+      # already prompts users who haven't opted in.
+      if ENV["OPENROUTER_API_KEY"].blank?
+        Rails.logger.warn("RoundOrchestrator: requester=#{@requester.id} skipped — OPENROUTER_API_KEY blank")
+        return nil
+      end
+      unless @requester.matchmaking_ready?
+        Rails.logger.warn("RoundOrchestrator: requester=#{@requester.id} skipped — not matchmaking_ready")
+        return nil
+      end
 
       candidates = eligible_candidates
-      return nil if candidates.empty?
+      if candidates.empty?
+        Rails.logger.warn("RoundOrchestrator: requester=#{@requester.id} has no eligible candidates")
+        return record_error("No other opted-in users to pitch right now. Ask a teammate to opt in on Settings.")
+      end
 
       pitch = SecretaryPitchService.new(@requester, candidates).call
-      return nil unless pitch
+      unless pitch
+        Rails.logger.warn("RoundOrchestrator: requester=#{@requester.id} got no pitch from SecretaryPitchService")
+        return record_error("Your AI couldn't generate an invitation. The AI service was unreachable, " \
+                            "rate-limited, or returned unparseable output — see Heroku logs for details.")
+      end
 
       target = pitch.target_user
-      return nil unless candidates.include?(target) && target != @requester
+      unless candidates.include?(target) && target != @requester
+        Rails.logger.warn("RoundOrchestrator: requester=#{@requester.id} got invalid target=#{target&.id}")
+        return record_error("Your AI picked an invalid target. See Heroku logs for details.")
+      end
 
       review = SecretaryReviewService.new(target, @requester.display_label, pitch.pitch_text).call
 
@@ -45,6 +65,19 @@ module Matchmaking
     end
 
     private
+
+    # Record a visible :error proposal so the failure surfaces on the Matches
+    # page instead of vanishing. Recipient is nil because we didn't reach the
+    # point of picking one (or the one we picked was rejected as invalid).
+    def record_error(reason)
+      MeetingProposal.create!(
+        requester:                  @requester,
+        recipient:                  nil,
+        status:                     :error,
+        decision_reason:            reason,
+        requester_profile_snapshot: @requester.meeting_interests
+      )
+    end
 
     # Opted-in users other than the requester, excluding pairs proposed recently.
     def eligible_candidates

--- a/app/services/matchmaking/secretary_pitch_service.rb
+++ b/app/services/matchmaking/secretary_pitch_service.rb
@@ -35,7 +35,11 @@ module Matchmaking
         )
       end
       parse(response.dig("choices", 0, "message", "content"))
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error(
+        "SecretaryPitchService: requester=#{@requester.id} failed with " \
+        "#{e.class}: #{e.message}"
+      )
       nil
     end
 
@@ -43,14 +47,32 @@ module Matchmaking
 
     def parse(content)
       data = extract_json(content)
-      return nil unless data
+      unless data
+        Rails.logger.warn(
+          "SecretaryPitchService: requester=#{@requester.id} returned " \
+          "unparseable output (no JSON object found): #{content.to_s.truncate(200)}"
+        )
+        return nil
+      end
 
       choice = data["choice"]
       pitch  = data["pitch"].to_s.strip
-      return nil if choice.blank? || pitch.blank?
+      if choice.blank? || pitch.blank?
+        Rails.logger.warn(
+          "SecretaryPitchService: requester=#{@requester.id} returned JSON " \
+          "with missing choice/pitch: #{data.inspect.truncate(200)}"
+        )
+        return nil
+      end
 
       index = choice.to_i - 1
-      return nil unless index.between?(0, @candidates.size - 1)
+      unless index.between?(0, @candidates.size - 1)
+        Rails.logger.warn(
+          "SecretaryPitchService: requester=#{@requester.id} picked " \
+          "out-of-range choice=#{choice.inspect} (candidates=#{@candidates.size})"
+        )
+        return nil
+      end
 
       PitchResult.new(@candidates[index], pitch)
     end

--- a/app/services/matchmaking/secretary_review_service.rb
+++ b/app/services/matchmaking/secretary_review_service.rb
@@ -34,7 +34,11 @@ module Matchmaking
         )
       end
       parse(response.dig("choices", 0, "message", "content"))
-    rescue StandardError
+    rescue StandardError => e
+      Rails.logger.error(
+        "SecretaryReviewService: recipient=#{@recipient.id} failed with " \
+        "#{e.class}: #{e.message}; falling back to decline"
+      )
       decline(FALLBACK_REASON)
     end
 

--- a/app/views/meeting_proposals/index.html.erb
+++ b/app/views/meeting_proposals/index.html.erb
@@ -31,13 +31,17 @@
         <div class="d-flex align-items-center justify-content-between">
           <div class="min-w-0">
             <div class="fw-semibold text-truncate">
-              <% if proposal.requester_id == current_user.id %>
-                <i class="bi bi-arrow-up-right text-muted me-1"></i>Your AI pitched <%= other.display_label %>
+              <% if proposal.error? %>
+                <i class="bi bi-exclamation-triangle text-danger me-1"></i>Run failed
+              <% elsif proposal.requester_id == current_user.id %>
+                <i class="bi bi-arrow-up-right text-muted me-1"></i>Your AI pitched <%= other&.display_label %>
               <% else %>
-                <i class="bi bi-arrow-down-left text-muted me-1"></i><%= other.display_label %>'s AI pitched you
+                <i class="bi bi-arrow-down-left text-muted me-1"></i><%= other&.display_label %>'s AI pitched you
               <% end %>
             </div>
-            <div class="text-muted small text-truncate"><%= proposal.pitch %></div>
+            <div class="text-muted small text-truncate">
+              <%= proposal.error? ? proposal.decision_reason : proposal.pitch %>
+            </div>
           </div>
           <div class="text-end flex-shrink-0 ms-3">
             <span class="badge <%= status_badge[proposal.status] %>"><%= proposal.status.titleize %></span>

--- a/app/views/meeting_proposals/show.html.erb
+++ b/app/views/meeting_proposals/show.html.erb
@@ -17,41 +17,60 @@
 
     <div class="d-flex align-items-center justify-content-between mb-3">
       <h1 class="h5 fw-bold mb-0">
-        <%= @proposal.requester.display_label %> &rarr; <%= @proposal.recipient.display_label %>
+        <% if @proposal.error? %>
+          <i class="bi bi-exclamation-triangle text-danger me-1"></i>Run failed
+        <% else %>
+          <%= @proposal.requester.display_label %> &rarr; <%= @proposal.recipient.display_label %>
+        <% end %>
       </h1>
       <span class="badge <%= status_badge[@proposal.status] %>"><%= @proposal.status.titleize %></span>
     </div>
 
-    <%# Requester's pitch %>
-    <div class="card mb-3">
-      <div class="card-header fw-semibold">
-        <i class="bi bi-robot me-1"></i><%= @proposal.requester.display_label %>'s secretary pitched:
+    <% if @proposal.error? %>
+      <%# Loud-failure row: surfaces a round that died (rate-limited, unparseable
+          AI output, no candidates, unexpected exception) so the user sees what
+          went wrong instead of nothing appearing. %>
+      <div class="alert alert-danger">
+        <div class="fw-semibold mb-1">
+          <i class="bi bi-exclamation-triangle me-1"></i>This round didn't complete.
+        </div>
+        <p class="mb-0"><%= @proposal.decision_reason.presence || "No reason recorded — see Heroku logs." %></p>
       </div>
-      <div class="card-body">
-        <p class="mb-2"><%= @proposal.pitch.presence || "—" %></p>
-        <% if @proposal.requester_profile_snapshot.present? %>
-          <div class="text-muted small">
-            <span class="fw-semibold">Their interests:</span> <%= @proposal.requester_profile_snapshot %>
-          </div>
-        <% end %>
+      <p class="text-muted small">
+        Try again — the most common cause is the free Gemma model being temporarily rate-limited upstream.
+      </p>
+    <% else %>
+      <%# Requester's pitch %>
+      <div class="card mb-3">
+        <div class="card-header fw-semibold">
+          <i class="bi bi-robot me-1"></i><%= @proposal.requester.display_label %>'s secretary pitched:
+        </div>
+        <div class="card-body">
+          <p class="mb-2"><%= @proposal.pitch.presence || "—" %></p>
+          <% if @proposal.requester_profile_snapshot.present? %>
+            <div class="text-muted small">
+              <span class="fw-semibold">Their interests:</span> <%= @proposal.requester_profile_snapshot %>
+            </div>
+          <% end %>
+        </div>
       </div>
-    </div>
 
-    <%# Recipient's verdict %>
-    <div class="card mb-3">
-      <div class="card-header fw-semibold">
-        <i class="bi bi-robot me-1"></i><%= @proposal.recipient.display_label %>'s secretary
-        <%= @proposal.accepted? ? "accepted" : "declined" %>:
+      <%# Recipient's verdict %>
+      <div class="card mb-3">
+        <div class="card-header fw-semibold">
+          <i class="bi bi-robot me-1"></i><%= @proposal.recipient.display_label %>'s secretary
+          <%= @proposal.accepted? ? "accepted" : "declined" %>:
+        </div>
+        <div class="card-body">
+          <p class="mb-2"><%= @proposal.decision_reason.presence || "—" %></p>
+          <% if @proposal.recipient_profile_snapshot.present? %>
+            <div class="text-muted small">
+              <span class="fw-semibold">Their interests:</span> <%= @proposal.recipient_profile_snapshot %>
+            </div>
+          <% end %>
+        </div>
       </div>
-      <div class="card-body">
-        <p class="mb-2"><%= @proposal.decision_reason.presence || "—" %></p>
-        <% if @proposal.recipient_profile_snapshot.present? %>
-          <div class="text-muted small">
-            <span class="fw-semibold">Their interests:</span> <%= @proposal.recipient_profile_snapshot %>
-          </div>
-        <% end %>
-      </div>
-    </div>
+    <% end %>
 
     <%# Outcome %>
     <% if @proposal.accepted? %>

--- a/db/migrate/20260528230000_allow_null_recipient_on_meeting_proposals.rb
+++ b/db/migrate/20260528230000_allow_null_recipient_on_meeting_proposals.rb
@@ -1,0 +1,9 @@
+class AllowNullRecipientOnMeetingProposals < ActiveRecord::Migration[8.1]
+  # Make recipient_id nullable so the orchestrator can record an :error proposal
+  # for a round that died before a target was chosen (e.g. the pitch service was
+  # rate-limited and never returned). Visible on the Matches page so silent
+  # failures stop being silent.
+  def change
+    change_column_null :meeting_proposals, :recipient_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_05_27_120001) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_28_230000) do
   create_table "event_participants", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "event_id", null: false
@@ -52,7 +52,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_05_27_120001) do
     t.text "decision_reason"
     t.datetime "meeting_at"
     t.text "pitch"
-    t.integer "recipient_id", null: false
+    t.integer "recipient_id"
     t.text "recipient_profile_snapshot"
     t.integer "requester_id", null: false
     t.text "requester_profile_snapshot"

--- a/spec/jobs/run_matchmaking_job_spec.rb
+++ b/spec/jobs/run_matchmaking_job_spec.rb
@@ -64,6 +64,9 @@ RSpec.describe RunMatchmakingJob, type: :job do
 
       expect { described_class.new.perform }.not_to raise_error
       expect(ok).to have_received(:call)
+      # The failing user's round records an :error proposal so the user can see
+      # it on the Matches page instead of nothing happening.
+      expect(MeetingProposal.where(requester: ready_a, status: :error).count).to eq(1)
     end
   end
 end

--- a/spec/models/meeting_proposal_spec.rb
+++ b/spec/models/meeting_proposal_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe MeetingProposal, type: :model do
   describe "associations" do
     it { is_expected.to belong_to(:requester).class_name("User") }
-    it { is_expected.to belong_to(:recipient).class_name("User") }
+    it { is_expected.to belong_to(:recipient).class_name("User").optional }
   end
 
   describe "status enum" do
@@ -19,6 +19,11 @@ RSpec.describe MeetingProposal, type: :model do
       proposal = build(:meeting_proposal, requester: user, recipient: user)
       expect(proposal).not_to be_valid
       expect(proposal.errors[:recipient_id]).to be_present
+    end
+
+    it "allows recipient to be nil (used by :error rows for failed rounds)" do
+      proposal = build(:meeting_proposal, requester: create(:user), recipient: nil, status: :error)
+      expect(proposal).to be_valid
     end
   end
 
@@ -56,6 +61,12 @@ RSpec.describe MeetingProposal, type: :model do
       create(:meeting_proposal, requester: bob, recipient: alice, created_at: 1.day.ago)
       expect(described_class.recently_proposed_between?(alice, bob)).to be(false)
     end
+
+    it "ignores :error rows (a failed round shouldn't block a real retry)" do
+      create(:meeting_proposal, requester: alice, recipient: bob,
+                                status: :error, created_at: 1.day.ago)
+      expect(described_class.recently_proposed_between?(alice, bob)).to be(false)
+    end
   end
 
   describe "#other_party" do
@@ -69,6 +80,11 @@ RSpec.describe MeetingProposal, type: :model do
 
     it "returns the requester for the recipient" do
       expect(proposal.other_party(bob)).to eq(alice)
+    end
+
+    it "returns nil when called by the requester of a recipient-less :error row" do
+      error_row = create(:meeting_proposal, requester: alice, recipient: nil, status: :error)
+      expect(error_row.other_party(alice)).to be_nil
     end
   end
 end

--- a/spec/services/matchmaking/round_orchestrator_service_spec.rb
+++ b/spec/services/matchmaking/round_orchestrator_service_spec.rb
@@ -114,32 +114,41 @@ RSpec.describe Matchmaking::RoundOrchestratorService, type: :service do
       end
     end
 
-    context "guards" do
-      it "returns nil when the API key is absent" do
+    context "guards (records :error proposals when a round fails, so the user sees it)" do
+      it "returns nil and records nothing when the API key is absent" do
         allow(ENV).to receive(:[]).with("OPENROUTER_API_KEY").and_return(nil)
         expect(service.call).to be_nil
         expect(MeetingProposal.count).to eq(0)
       end
 
-      it "returns nil when the requester is not matchmaking-ready" do
+      it "returns nil and records nothing when the requester is not matchmaking-ready" do
         requester.update!(matchmaking_enabled: false)
         expect(service.call).to be_nil
+        expect(MeetingProposal.count).to eq(0)
       end
 
-      it "returns nil when there are no eligible candidates" do
+      it "records an :error proposal when there are no eligible candidates" do
         target.update!(matchmaking_enabled: false)
-        expect(service.call).to be_nil
+        result = service.call
+        expect(result).to be_error
+        expect(result.recipient).to be_nil
+        expect(result.decision_reason).to match(/no other opted-in users/i)
       end
 
-      it "returns nil when the pitch service yields nothing" do
+      it "records an :error proposal when the pitch service yields nothing" do
         stub_pitch(nil)
-        expect(service.call).to be_nil
+        result = service.call
+        expect(result).to be_error
+        expect(result.recipient).to be_nil
+        expect(result.decision_reason).to match(/couldn't generate an invitation/i)
       end
 
-      it "skips candidates proposed within the recency window" do
+      it "skips candidates proposed within the recency window (records an :error proposal)" do
         create(:meeting_proposal, requester: requester, recipient: target, created_at: 1.day.ago)
-        expect(service.call).to be_nil
-        expect(MeetingProposal.count).to eq(1) # only the pre-existing one; no new proposal
+        result = service.call
+        expect(result).to be_error
+        # Two MeetingProposals total: the pre-existing one + the new :error row.
+        expect(MeetingProposal.count).to eq(2)
       end
     end
   end


### PR DESCRIPTION
Per the loud-errors-over-silent-ones rule, a matchmaking round that died never used to leave a trace: the orchestrator returned nil and the user saw nothing on the Matches page. The free Gemma model is heavily rate-limited upstream right now, which made this the modal outcome on prod.

Three layers of loudness:

1. Logs: every silent path now logs why it bailed.
   - SecretaryPitchService logs the exception class+message on rescue instead of swallowing it, and logs each parse failure (no JSON, missing fields, out-of-range choice) with a 200-char excerpt.
   - SecretaryReviewService logs the exception before falling back to decline.
   - RateLimitedChat logs an error when 429 retries are exhausted before re-raising.
   - RoundOrchestratorService logs at every return-nil path.

2. UI: failed rounds now create a visible MeetingProposal row.
   - New migration: meeting_proposals.recipient_id is nullable.
   - MeetingProposal: recipient is optional; the requester-not-equal-recipient validation skips nil recipients; recently_proposed_between? ignores :error rows so a failed round doesn't gate a real retry; other_party returns nil for a recipient-less :error row.
   - RoundOrchestratorService and RunMatchmakingJob both record :error rows with a decision_reason explaining what went wrong (no candidates, AI unreachable, invalid target, unexpected exception).
   - The Matches index and show pages render :error rows with a red badge, an exclamation icon, and the reason — instead of the usual pitch/verdict cards.

3. Tests cover the new behavior: nullable recipient, recently- proposed-between ignores errors, other_party with nil recipient, each orchestrator guard records the expected :error row, and the job's per-user rescue records one too.