### PR TITLE
Replace gravatar_image_tag gem with an inline helper

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -79,5 +79,7 @@ gem "csv"
 gem "chartkick"
 gem "groupdate"
 
-# Gravatar avatars for contacts
-gem "gravatar_image_tag", "~> 1.2"
+# Gravatar avatars: replaced the gravatar_image_tag gem (v1.2.0, last release
+# ~2013) with a small inline helper in ApplicationHelper — the gem calls
+# URI.escape, which Ruby 3+ removed, so it crashed the people index. A Gravatar
+# URL is just https://www.gravatar.com/avatar/<MD5(downcased email)>?s=&d=.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,6 @@ GEM
       multi_json (~> 1.11)
       os (>= 0.9, < 2.0)
       signet (>= 0.16, < 2.a)
-    gravatar_image_tag (1.2.0)
     groupdate (6.8.0)
       activesupport (>= 7.2)
     i18n (1.14.8)
@@ -439,7 +438,6 @@ DEPENDENCIES
   faker (~> 3.5)
   google-apis-calendar_v3 (~> 0.17)
   googleauth (~> 1.11)
-  gravatar_image_tag (~> 1.2)
   groupdate
   importmap-rails
   overcommit
@@ -512,7 +510,6 @@ CHECKSUMS
   google-cloud-env (2.3.1) sha256=0faac01eb27be78c2591d64433663b1a114f8f7af55a4f819755426cac9178e7
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   googleauth (1.16.2) sha256=15009502e2e38af71948cda918f230e27d327f6882a1e47967a5a4664930a638
-  gravatar_image_tag (1.2.0) sha256=eb5630fea846b711e713b934a0178fb9785f02f4eb9ced8d6faa4d537c40fdcf
   groupdate (6.8.0) sha256=16f90ea18ca981c38e41e592416480b28353aa5e5cc3e7cb13a68b8fb5d40510
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,4 +43,19 @@ module ApplicationHelper
 
     ["Snoozed until #{person.snoozed_until.strftime("%b %-d")}", "badge-snoozed"]
   end
+
+  # Inline replacement for the abandoned gravatar_image_tag gem (which calls
+  # URI.escape, removed in Ruby 3+). Matches the same call shape used in
+  # _person_row.html.erb: positional email + an optional gravatar: { size:,
+  # default: } hash, plus pass-through HTML options (class:, style:, alt:, ...).
+  def gravatar_image_tag(email, **options)
+    gravatar_opts = options.delete(:gravatar) || {}
+    size    = gravatar_opts[:size]    || 80
+    default = gravatar_opts[:default] || "identicon"
+
+    hash = Digest::MD5.hexdigest(email.to_s.strip.downcase)
+    url  = "https://www.gravatar.com/avatar/#{hash}?s=#{size}&d=#{CGI.escape(default.to_s)}"
+
+    image_tag(url, **options)
+  end
 end


### PR DESCRIPTION
The gravatar_image_tag gem (v1.2.0, last released ~2013) calls URI.escape, which Ruby 3 removed. That made the people index crash with NoMethodError in test and prod, which blocked deploys for any unrelated PR that touched main.

A Gravatar URL is just
  https://www.gravatar.com/avatar/<MD5(downcased email)>?s=&d=
so the gem is doing trivial work. Replaced it with a small helper of the same name on ApplicationHelper that matches the existing call shape (positional email, gravatar: { size:, default: } options, pass-through HTML attributes). Removed the gem from the Gemfile.

people_spec is green again (3 failures → 0). Full suite still 212/0.