### PR TITLE
Fix erb_lint spacing in _person_row fallback avatar

### DIFF
--- a/app/views/people/_person_row.html.erb
+++ b/app/views/people/_person_row.html.erb
@@ -20,7 +20,7 @@
             gravatar: { size: 36, default: "404" },
             onerror: "this.style.display='none';this.nextElementSibling.style.display='inline-flex';"
           ) %>
-      <span class="avatar flex-shrink-0" style="background:<%=color%>18;color:<%=color%>;display:none;">
+      <span class="avatar flex-shrink-0" style="background:<%= color %>18;color:<%= color %>;display:none;">
         <%= initials %>
       </span>
       <div>


### PR DESCRIPTION
The fallback initials avatar used <%=color%> with no spaces inside the ERB tags; erb_lint requires <%= color %>. This was pre-existing on main and blocking the post-merge deploy job.