### PR TITLE
Surface unevaluable AI reviews as errors, not declines

### DIFF
--- a/app/models/meeting_proposal.rb
+++ b/app/models/meeting_proposal.rb
@@ -5,8 +5,11 @@
 #
 # Schema (see db/schema.rb for the authoritative version):
 #   requester_id  :integer not null  (FK -> users)
-#   recipient_id  :integer nullable  (FK -> users; nil only on :error proposals
-#                                     where the round died before a target was picked)
+#   recipient_id  :integer nullable  (FK -> users; nil on :error proposals where
+#                                     the round died before a target was picked.
+#                                     An :error row CAN have a recipient when the
+#                                     target was chosen but their secretary failed
+#                                     to evaluate the pitch.)
 #   status        :integer not null  (enum below)
 #   pitch / decision_reason   :text    nullable
 #   *_profile_snapshot        :text    nullable

--- a/app/services/matchmaking/round_orchestrator_service.rb
+++ b/app/services/matchmaking/round_orchestrator_service.rb
@@ -50,6 +50,14 @@ module Matchmaking
 
       review = SecretaryReviewService.new(target, @requester.display_label, pitch.pitch_text).call
 
+      # An "unevaluable" review (AI unreachable/rate-limited/garbled) isn't a real
+      # decline — record it as a loud :error (keeping the target + pitch for
+      # context) so it's visually distinct from a secretary's genuine "no".
+      if review.error
+        Rails.logger.warn("RoundOrchestrator: requester=#{@requester.id} review unevaluable for target=#{target.id}")
+        return record_review_error(target, pitch.pitch_text, review.reason)
+      end
+
       proposal = MeetingProposal.create!(
         requester:                  @requester,
         recipient:                  target,
@@ -76,6 +84,21 @@ module Matchmaking
         status:                     :error,
         decision_reason:            reason,
         requester_profile_snapshot: @requester.meeting_interests
+      )
+    end
+
+    # Like record_error, but for a round that got far enough to pick a target and
+    # write a pitch before the recipient's secretary failed to evaluate it. Keeps
+    # the recipient + pitch so the Matches page can show what was attempted.
+    def record_review_error(target, pitch_text, reason)
+      MeetingProposal.create!(
+        requester:                  @requester,
+        recipient:                  target,
+        status:                     :error,
+        pitch:                      pitch_text,
+        decision_reason:            reason,
+        requester_profile_snapshot: @requester.meeting_interests,
+        recipient_profile_snapshot: target.meeting_interests
       )
     end
 

--- a/app/services/matchmaking/secretary_review_service.rb
+++ b/app/services/matchmaking/secretary_review_service.rb
@@ -4,9 +4,17 @@ module Matchmaking
   # fail-safe: any error, blank, or unparseable response DECLINES, so we never
   # auto-schedule a meeting off ambiguous model output.
   class SecretaryReviewService
-    FALLBACK_REASON = "Your secretary could not evaluate this request, so it was declined."
+    # Shown when the secretary couldn't actually evaluate the pitch (the call
+    # raised, came back blank, or was unparseable). This is an ERROR, not a real
+    # "no" — ReviewResult#error is set so the orchestrator can surface it loudly
+    # instead of as a normal decline.
+    FALLBACK_REASON = "The recipient's AI secretary couldn't evaluate this pitch — the AI " \
+                      "service was unreachable, rate-limited, or returned unreadable output, " \
+                      "so no decision was made. Try again; check the server logs if it persists."
 
-    ReviewResult = Struct.new(:accepted, :reason, keyword_init: true)
+    # error: true marks the fail-safe path (couldn't evaluate) as distinct from a
+    # genuine accept/decline so the UI can treat it as an error rather than a "no".
+    ReviewResult = Struct.new(:accepted, :reason, :error, keyword_init: true)
 
     def initialize(recipient, requester_label, pitch_text)
       @recipient       = recipient
@@ -26,15 +34,15 @@ module Matchmaking
     rescue StandardError => e
       Rails.logger.error(
         "SecretaryReviewService: recipient=#{@recipient.id} failed with " \
-        "#{e.class}: #{e.message}; falling back to decline"
+        "#{e.class}: #{e.message}; recording an evaluation error"
       )
-      decline(FALLBACK_REASON)
+      unevaluable
     end
 
     private
 
     def parse(content)
-      return decline(FALLBACK_REASON) if content.blank?
+      return unevaluable if content.blank?
 
       data = extract_json(content)
       if data
@@ -50,16 +58,22 @@ module Matchmaking
       if lowered.include?("accept") && !lowered.include?("decline")
         accept(content.strip.truncate(200))
       else
-        decline(FALLBACK_REASON)
+        unevaluable
       end
     end
 
     def accept(reason)
-      ReviewResult.new(accepted: true, reason: reason)
+      ReviewResult.new(accepted: true, reason: reason, error: false)
     end
 
     def decline(reason)
-      ReviewResult.new(accepted: false, reason: reason)
+      ReviewResult.new(accepted: false, reason: reason, error: false)
+    end
+
+    # The secretary couldn't actually evaluate the pitch. Not a real decline —
+    # flagged as an error so the round surfaces it as a failure, not a "no".
+    def unevaluable
+      ReviewResult.new(accepted: false, reason: FALLBACK_REASON, error: true)
     end
 
     def extract_json(content)

--- a/app/views/meeting_proposals/show.html.erb
+++ b/app/views/meeting_proposals/show.html.erb
@@ -36,6 +36,21 @@
         </div>
         <p class="mb-0"><%= @proposal.decision_reason.presence || "No reason recorded — see Heroku logs." %></p>
       </div>
+
+      <%# When the round got as far as pitching a target before failing, show what
+          was attempted so the error has context (not just a bare message). %>
+      <% if @proposal.recipient && @proposal.pitch.present? %>
+        <div class="card mb-3 border-danger-subtle">
+          <div class="card-header fw-semibold text-muted">
+            <i class="bi bi-robot me-1"></i><%= @proposal.requester.display_label %>'s secretary pitched
+            <%= @proposal.recipient.display_label %>, but their secretary never responded:
+          </div>
+          <div class="card-body">
+            <p class="mb-0 text-muted"><%= @proposal.pitch %></p>
+          </div>
+        </div>
+      <% end %>
+
       <p class="text-muted small">
         Try again. The message above is the actual reason this round failed; see the
         server logs for more detail if it persists.

--- a/spec/services/matchmaking/round_orchestrator_service_spec.rb
+++ b/spec/services/matchmaking/round_orchestrator_service_spec.rb
@@ -17,8 +17,10 @@ RSpec.describe Matchmaking::RoundOrchestratorService, type: :service do
     allow(Matchmaking::SecretaryPitchService).to receive(:new).and_return(pitch_service)
   end
 
-  def stub_review(accepted:, reason: "because")
-    review = Matchmaking::SecretaryReviewService::ReviewResult.new(accepted: accepted, reason: reason)
+  def stub_review(accepted:, reason: "because", error: false)
+    review = Matchmaking::SecretaryReviewService::ReviewResult.new(
+      accepted: accepted, reason: reason, error: error
+    )
     review_service = instance_double(Matchmaking::SecretaryReviewService, call: review)
     allow(Matchmaking::SecretaryReviewService).to receive(:new).and_return(review_service)
   end
@@ -59,6 +61,19 @@ RSpec.describe Matchmaking::RoundOrchestratorService, type: :service do
 
         service.call
         expect(MeetingProposal.last).to be_declined
+      end
+
+      it "records an :error proposal (not a decline) when the review can't be evaluated" do
+        stub_pitch(pitch_for(target))
+        stub_review(accepted: false, reason: "AI was unreachable", error: true)
+        expect(GoogleCalendarService).not_to receive(:new)
+
+        result = service.call
+        expect(result).to be_error
+        # The target + pitch are retained so the Matches page can show context.
+        expect(result.recipient).to eq(target)
+        expect(result.pitch).to eq("Let's meet")
+        expect(result.decision_reason).to eq("AI was unreachable")
       end
     end
 

--- a/spec/services/matchmaking/secretary_review_service_spec.rb
+++ b/spec/services/matchmaking/secretary_review_service_spec.rb
@@ -22,24 +22,31 @@ RSpec.describe Matchmaking::SecretaryReviewService, type: :service do
       result = service.call
       expect(result.accepted).to be(true)
       expect(result.reason).to eq("Good fit")
+      expect(result.error).to be(false)
     end
 
-    it "declines on a clean decline verdict" do
+    it "declines on a clean decline verdict (a genuine 'no', not an error)" do
       allow(client_double).to receive(:chat)
         .and_return(response_with('{"decision": "decline", "reason": "Not relevant"}'))
       result = service.call
       expect(result.accepted).to be(false)
       expect(result.reason).to eq("Not relevant")
+      expect(result.error).to be(false)
     end
 
-    it "declines (fail-safe) on unparseable output" do
+    it "flags an evaluation error (not a decline) on unparseable output" do
       allow(client_double).to receive(:chat).and_return(response_with("???"))
-      expect(service.call.accepted).to be(false)
+      result = service.call
+      expect(result.accepted).to be(false)
+      expect(result.error).to be(true)
+      expect(result.reason).to eq(described_class::FALLBACK_REASON)
     end
 
-    it "declines (fail-safe) when the API raises" do
+    it "flags an evaluation error (not a decline) when the API raises" do
       allow(client_double).to receive(:chat).and_raise(StandardError, "boom")
-      expect(service.call.accepted).to be(false)
+      result = service.call
+      expect(result.accepted).to be(false)
+      expect(result.error).to be(true)
     end
 
     it "passes the recipient interests and the incoming pitch into the prompt" do


### PR DESCRIPTION
## What

A recipient's AI secretary that **can't evaluate** an incoming pitch (the AI service was unreachable, rate-limited, or returned unparseable output) was failing safe to a normal `:declined` proposal. On the Matches page that rendered identically to a genuine editorial decline — grey "Declined" badge, shown in the verdict card like real AI prose — so "the AI read your pitch and said no" looked exactly like "the AI never managed to read it."

This makes the unevaluable path an **error**, not a decline.

## Changes

- `SecretaryReviewService::ReviewResult` now carries an `error` flag. The three fail-safe paths (call raised / blank / unparseable) set `error: true` via a new `unevaluable` helper; genuine accept/decline stay `error: false`.
- `RoundOrchestratorService` records an `error: true` review as a loud `:error` proposal (keeping the target + pitch for context) instead of a `:declined` one — so it gets the existing red "Run failed / This round didn't complete" treatment and is visually distinct from a real "no".
- Reworded the fallback message to actually explain the failure and what to do, instead of the terse "could not evaluate this request, so it was declined."
- The match detail page shows the attempted pitch under the error when one exists.
- Side effect: `:error` rows are excluded from the recency window, so a transient evaluation failure no longer blocks re-pitching that pair.

## Verification

- `bundle exec rspec` affected specs → 16 examples, 0 failures (full suite was 219/0 on the source branch).
- rubocop clean on the Ruby files; erb_lint clean on the views.

## Note

This is a follow-up to #183 (already merged). #183 was squash-merged, so this branch is cut fresh from `main` with only the new commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
