### PR TITLE
Bump puma to 8.0.2 for CVE-2026-47736/47737

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,7 +328,7 @@ GEM
       date
       stringio
     public_suffix (7.0.5)
-    puma (8.0.0)
+    puma (8.0.2)
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
@@ -671,7 +671,7 @@ CHECKSUMS
   propshaft (1.3.2) sha256=1d56a3e56a92c21bfc29caf07406b5386b00d4c47ddf357cf989a5a234b1389e
   psych (5.3.1) sha256=eb7a57cef10c9d70173ff74e739d843ac3b2c019a003de48447b2963d81b1974
   public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
-  puma (8.0.0) sha256=1681050b8b60fab1d3033255ab58b6aec64cd063e43fc6f8204bcb8bf9364b88
+  puma (8.0.2) sha256=c8ed871dfbbe66448ea9ffd46692342d9804d4071522b52b5331b7b6e7b686fb
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
   rack (3.2.6) sha256=5ed78e1f73b2e25679bec7d45ee2d4483cc4146eb1be0264fc4d94cb5ef212c2
   rack-attack (6.8.0) sha256=f2499fdebf85bcc05573a22dff57d24305ac14ec2e4156cd3c28d47cafeeecf2


### PR DESCRIPTION
`scan_ruby` (bundler-audit) began failing on every branch's CI after the
ruby-advisory-db update on **2026-06-07** flagged **puma 8.0.0** for two
High-severity PROXY-protocol-v1 vulnerabilities:

- **CVE-2026-47736** — remote memory exhaustion in the PROXY v1 parser
- **CVE-2026-47737** — repeated protocol headers accepted on persistent connections

Fix: bump to the upstream patch release **8.0.2** (`bundle update puma --conservative`).
`Gemfile.lock` only — `Gemfile` already permits `>= 5.0`. Verified clean with
`bundler-audit` against the current advisory DB.

This is unrelated to any feature work; it's repo-wide dependency hygiene, split out
so feature PRs (e.g. #193) stay focused. After this merges, #193 will be rebased and
go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
