### PR TITLE
Fix missing template error in matches index from #151

### DIFF
--- a/app/views/meeting_proposals/index.html.erb
+++ b/app/views/meeting_proposals/index.html.erb
@@ -20,7 +20,7 @@
 
 <% if @proposals.any? %>
   <div class="list-group" id="proposals-list">
-    <%= render @proposals %>
+    <%= render partial: "proposal", collection: @proposals, as: :proposal %>
   </div>
 <% else %>
   <div class="text-center text-muted py-5" id="proposals-list">


### PR DESCRIPTION
render @proposals infers the partial name from the model class (MeetingProposal -> _meeting_proposal.html.erb), but the partial is named _proposal.html.erb. Use the explicit partial: / collection: form so Rails finds the right file.