### PR TITLE
Add smart scheduling negotiation for accepted matches, issue 178

### DIFF
--- a/app/controllers/scheduling_negotiations_controller.rb
+++ b/app/controllers/scheduling_negotiations_controller.rb
@@ -1,0 +1,79 @@
+class SchedulingNegotiationsController < ApplicationController
+  before_action :set_negotiation
+
+  def show
+  end
+
+  def confirm
+    slot = @negotiation.scheduling_slots.find_by(id: params[:slot_id])
+    return redirect_to scheduling_negotiation_path(@negotiation), alert: "Slot not found." unless slot
+
+    SchedulingNegotiation.transaction do
+      @negotiation.lock!
+      if !@negotiation.pending?
+        redirect_to scheduling_negotiation_path(@negotiation), alert: "This meeting has already been resolved." and return
+      end
+      if @negotiation.past_expiry?
+        redirect_to scheduling_negotiation_path(@negotiation), alert: "The scheduling window has expired." and return
+      end
+
+      slot.update!(confirmed_by: current_user)
+      @negotiation.confirmed!
+      @negotiation.meeting_proposal.update!(meeting_at: slot.starts_at)
+    end
+
+    book_calendar_event(slot)
+
+    @negotiation.parties.each { |p| SchedulingMailer.confirmed(@negotiation, p).deliver_later }
+    broadcast_proposal_update
+
+    redirect_to scheduling_negotiation_path(@negotiation), notice: "Meeting confirmed!"
+  end
+
+  private
+
+  def set_negotiation
+    @negotiation = SchedulingNegotiation
+      .includes(:scheduling_slots, meeting_proposal: [ :requester, :recipient ])
+      .find(params[:id])
+    unless @negotiation.parties.include?(current_user)
+      redirect_to matches_path, alert: "Not authorized." and return
+    end
+  end
+
+  def book_calendar_event(slot)
+    proposal = @negotiation.meeting_proposal
+    host     = proposal.requester.google_calendar_connected? ? proposal.requester : proposal.recipient
+    return unless host&.google_calendar_connected?
+
+    guest   = proposal.other_party(host)
+    service = GoogleCalendarService.new(host)
+    event   = service.push_user_meeting(
+      summary:          "Intro: #{proposal.requester.display_label} & #{proposal.recipient.display_label}",
+      description:      proposal.pitch,
+      start_time:       slot.starts_at,
+      duration_minutes: SchedulingSlot::DURATION_MINUTES,
+      attendee_emails:  [ guest.email ],
+      tz_name:          host.timezone
+    )
+    proposal.update!(
+      calendar_event_id:   event.id,
+      calendar_event_link: event.html_link,
+      calendar_created:    true
+    )
+  rescue StandardError => e
+    Rails.logger.warn("SchedulingNegotiationsController#book_calendar_event: #{e.message}")
+  end
+
+  def broadcast_proposal_update
+    proposal = @negotiation.meeting_proposal.reload
+    @negotiation.parties.each do |party|
+      Turbo::StreamsChannel.broadcast_update_to(
+        [ party, :matches ],
+        target:  dom_id(proposal),
+        partial: "meeting_proposals/proposal",
+        locals:  { proposal: proposal, current_user: party }
+      )
+    end
+  end
+end

--- a/app/jobs/create_scheduling_negotiation_job.rb
+++ b/app/jobs/create_scheduling_negotiation_job.rb
@@ -1,0 +1,80 @@
+class CreateSchedulingNegotiationJob < ApplicationJob
+  queue_as :default
+
+  SLOT_COUNT   = 5
+  WINDOW_DAYS  = 7
+  FROM_HOUR    = 9
+  TO_HOUR      = 17
+  DURATION     = 30.minutes
+
+  def perform(proposal_id)
+    proposal = MeetingProposal.find_by(id: proposal_id)
+    return unless proposal&.accepted?
+    return if proposal.scheduling_negotiation.present?
+
+    slots = find_free_slots(proposal)
+
+    negotiation = SchedulingNegotiation.create!(
+      meeting_proposal: proposal,
+      expires_at:       48.hours.from_now
+    )
+
+    slots.each { |t| negotiation.scheduling_slots.create!(starts_at: t) }
+
+    proposal.parties.each do |party|
+      SchedulingMailer.invite(negotiation, party).deliver_later
+    end
+  end
+
+  private
+
+  def find_free_slots(proposal)
+    busy   = merged_busy(proposal)
+    slots  = []
+    cursor = Time.current
+
+    SLOT_COUNT.times do
+      t = GoogleCalendarService.earliest_free_slot(
+        busy:          busy,
+        window_days:   WINDOW_DAYS,
+        from_hour:     FROM_HOUR,
+        to_hour:       TO_HOUR,
+        slot_duration: DURATION,
+        now:           cursor
+      )
+      break unless t
+      slots  << t
+      cursor  = t + DURATION
+    end
+
+    return slots unless slots.empty?
+
+    base = default_start(proposal.requester)
+    SLOT_COUNT.times.map { |i| base + (i * 2).hours }
+  end
+
+  def merged_busy(proposal)
+    raw = []
+    proposal.parties.each do |user|
+      next unless user.google_calendar_connected?
+      svc  = GoogleCalendarService.new(user)
+      raw += svc.busy_intervals(window_days: WINDOW_DAYS)
+    rescue StandardError => e
+      Rails.logger.warn("CreateSchedulingNegotiationJob: busy_intervals for user #{user.id}: #{e.message}")
+    end
+
+    raw.sort_by!(&:first)
+    raw.each_with_object([]) do |(s, e), acc|
+      if acc.empty? || s > acc.last[1]
+        acc << [s, e]
+      else
+        acc.last[1] = [acc.last[1], e].max
+      end
+    end
+  end
+
+  def default_start(user)
+    tz = ActiveSupport::TimeZone[user.timezone] || Time.zone
+    tz.now.tomorrow.change(hour: 10).utc
+  end
+end

--- a/app/jobs/expire_scheduling_negotiations_job.rb
+++ b/app/jobs/expire_scheduling_negotiations_job.rb
@@ -1,0 +1,14 @@
+class ExpireSchedulingNegotiationsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    SchedulingNegotiation.pending.where("expires_at < ?", Time.current).find_each do |negotiation|
+      negotiation.expired!
+      negotiation.parties.each do |party|
+        SchedulingMailer.expired(negotiation, party).deliver_later
+      end
+    rescue StandardError => e
+      Rails.logger.warn("ExpireSchedulingNegotiationsJob: negotiation #{negotiation.id}: #{e.message}")
+    end
+  end
+end

--- a/app/mailers/scheduling_mailer.rb
+++ b/app/mailers/scheduling_mailer.rb
@@ -1,0 +1,28 @@
+class SchedulingMailer < ApplicationMailer
+  def invite(negotiation, recipient)
+    @negotiation = negotiation
+    @recipient   = recipient
+    @proposal    = negotiation.meeting_proposal
+    @other       = @proposal.other_party(recipient)
+    @url         = scheduling_negotiation_url(negotiation)
+    @expires_at  = negotiation.expires_at
+    mail(to: recipient.email, subject: "Choose a time to meet #{@other&.display_label}")
+  end
+
+  def confirmed(negotiation, recipient)
+    @negotiation = negotiation
+    @recipient   = recipient
+    @proposal    = negotiation.meeting_proposal
+    @other       = @proposal.other_party(recipient)
+    @slot        = negotiation.confirmed_slot
+    mail(to: recipient.email, subject: "Meeting confirmed with #{@other&.display_label}")
+  end
+
+  def expired(negotiation, recipient)
+    @negotiation = negotiation
+    @recipient   = recipient
+    @proposal    = negotiation.meeting_proposal
+    @other       = @proposal.other_party(recipient)
+    mail(to: recipient.email, subject: "Scheduling window expired")
+  end
+end

--- a/app/models/meeting_proposal.rb
+++ b/app/models/meeting_proposal.rb
@@ -24,6 +24,7 @@ class MeetingProposal < ApplicationRecord
 
   belongs_to :requester, class_name: "User"
   belongs_to :recipient, class_name: "User", optional: true
+  has_one    :scheduling_negotiation, dependent: :destroy
 
   # :error rows record a round that couldn't complete (model rate-limited,
   # unparseable AI output, no candidates, etc.) so the failure shows up on the
@@ -45,6 +46,11 @@ class MeetingProposal < ApplicationRecord
       .where.not(status: :error)
       .where(created_at: RECENCY_WINDOW.ago..)
       .exists?
+  end
+
+  # Both parties on this proposal; nil recipient (error rows) are excluded.
+  def parties
+    [ requester, recipient ].compact
   end
 
   # The party who is not the given user. Nil if this is an error row that never

--- a/app/models/scheduling_negotiation.rb
+++ b/app/models/scheduling_negotiation.rb
@@ -1,0 +1,20 @@
+class SchedulingNegotiation < ApplicationRecord
+  belongs_to :meeting_proposal
+  has_many   :scheduling_slots, dependent: :destroy
+
+  enum :status, { pending: 0, confirmed: 1, expired: 2 }
+
+  delegate :requester, :recipient, to: :meeting_proposal
+
+  def parties
+    [ requester, recipient ].compact
+  end
+
+  def confirmed_slot
+    scheduling_slots.where.not(confirmed_by_id: nil).first
+  end
+
+  def past_expiry?
+    expires_at < Time.current
+  end
+end

--- a/app/models/scheduling_slot.rb
+++ b/app/models/scheduling_slot.rb
@@ -1,0 +1,14 @@
+class SchedulingSlot < ApplicationRecord
+  belongs_to :scheduling_negotiation
+  belongs_to :confirmed_by, class_name: "User", optional: true
+
+  DURATION_MINUTES = 30
+
+  def confirmed?
+    confirmed_by_id.present?
+  end
+
+  def ends_at
+    starts_at + DURATION_MINUTES.minutes
+  end
+end

--- a/app/services/matchmaking/round_orchestrator_service.rb
+++ b/app/services/matchmaking/round_orchestrator_service.rb
@@ -6,11 +6,6 @@ module Matchmaking
   # LLM-calling services stay side-effect free. Returns the proposal, or nil when no
   # proposal was made.
   class RoundOrchestratorService
-    SLOT_WINDOW_DAYS         = 7
-    SLOT_FROM_HOUR           = 9
-    SLOT_TO_HOUR             = 17
-    MEETING_DURATION_MINUTES = 30
-
     def initialize(requester)
       @requester = requester
     end
@@ -68,7 +63,11 @@ module Matchmaking
         recipient_profile_snapshot: target.meeting_interests
       )
 
-      create_calendar_event(proposal) if proposal.accepted?
+      if proposal.accepted?
+        if proposal.requester.google_calendar_connected? || proposal.recipient&.google_calendar_connected?
+          CreateSchedulingNegotiationJob.perform_later(proposal.id)
+        end
+      end
       proposal
     end
 
@@ -113,48 +112,5 @@ module Matchmaking
           .reject { |candidate| MeetingProposal.recently_proposed_between?(@requester, candidate) }
     end
 
-    # Mirrors the existing event flow: the connected party hosts (their calendar is
-    # checked and the event lands on it); the other is added purely as an attendee
-    # email. Only the host needs Google connected. Record-only fallback on any error.
-    def create_calendar_event(proposal)
-      host  = proposal.requester.google_calendar_connected? ? proposal.requester : proposal.recipient
-      return unless host.google_calendar_connected?
-
-      guest   = proposal.other_party(host)
-      service = GoogleCalendarService.new(host)
-      tz      = ActiveSupport::TimeZone[host.timezone] || Time.zone
-      busy    = service.busy_intervals(window_days: SLOT_WINDOW_DAYS)
-      start_time = GoogleCalendarService.earliest_free_slot(
-        busy:          busy,
-        window_days:   SLOT_WINDOW_DAYS,
-        from_hour:     SLOT_FROM_HOUR,
-        to_hour:       SLOT_TO_HOUR,
-        slot_duration: MEETING_DURATION_MINUTES.minutes,
-        tz:            tz
-      ) || default_slot(host)
-
-      event = service.push_user_meeting(
-        summary:          "Intro: #{proposal.requester.display_label} & #{proposal.recipient.display_label}",
-        description:      proposal.pitch,
-        start_time:       start_time,
-        duration_minutes: MEETING_DURATION_MINUTES,
-        attendee_emails:  [guest.email],
-        tz_name:          host.timezone
-      )
-
-      proposal.update!(
-        meeting_at:          start_time,
-        calendar_event_id:   event.id,
-        calendar_event_link: event.html_link,
-        calendar_created:    true
-      )
-    rescue StandardError => e
-      Rails.logger.warn("Matchmaking calendar event failed for proposal #{proposal.id}: #{e.message}")
-    end
-
-    def default_slot(host)
-      tz = ActiveSupport::TimeZone[host.timezone] || Time.zone
-      tz.now.tomorrow.change(hour: 10).utc
-    end
   end
 end

--- a/app/views/meeting_proposals/show.html.erb
+++ b/app/views/meeting_proposals/show.html.erb
@@ -113,14 +113,43 @@
 
     <%# Outcome %>
     <% if @proposal.accepted? %>
-      <% if @proposal.calendar_created? %>
+      <% negotiation = @proposal.scheduling_negotiation %>
+      <% if negotiation %>
+        <% if negotiation.confirmed? %>
+          <% slot = negotiation.confirmed_slot %>
+          <div class="alert alert-success">
+            <i class="bi bi-calendar-check me-1"></i>
+            Meeting confirmed for
+            <%= slot&.starts_at&.in_time_zone(current_user.timezone)
+                  &.strftime("%A, %B %-d at %-I:%M %p %Z") %>.
+            <% link_url = @proposal.calendar_event_link.to_s %>
+            <% if link_url.start_with?("https://") %>
+              <%= link_to "Open in Google Calendar", link_url,
+                    class: "alert-link ms-1", target: "_blank", rel: "noopener noreferrer" %>
+            <% end %>
+          </div>
+        <% elsif negotiation.expired? %>
+          <div class="alert alert-secondary">
+            <i class="bi bi-clock-history me-1"></i>
+            The scheduling window expired. Run matchmaking again to try a new match.
+          </div>
+        <% else %>
+          <div class="alert alert-info d-flex align-items-center justify-content-between gap-3">
+            <div>
+              <i class="bi bi-calendar2-check me-1"></i>
+              <strong>Waiting for a time slot to be confirmed.</strong>
+              Window closes <%= negotiation.expires_at.in_time_zone(current_user.timezone)
+                                   .strftime("%b %-d at %-I:%M %p %Z") %>.
+            </div>
+            <%= link_to scheduling_negotiation_path(negotiation), class: "btn btn-primary btn-sm flex-shrink-0" do %>
+              <i class="bi bi-calendar-event me-1"></i>Choose a time
+            <% end %>
+          </div>
+        <% end %>
+      <% elsif @proposal.calendar_created? %>
         <div class="alert alert-success">
           <i class="bi bi-calendar-check me-1"></i>
           Meeting scheduled<%= " for #{l(@proposal.meeting_at, format: :short)}" if @proposal.meeting_at %>.
-          <%# Guard the href: only render the link if the stored URL is a real
-              https URL. Brakeman flags model-derived hrefs because, untrusted,
-              they could be a "javascript:" URL. The value comes from Google's
-              event.html_link, but we still verify the scheme here defensively. %>
           <% link_url = @proposal.calendar_event_link.to_s %>
           <% if link_url.start_with?("https://") %>
             <%= link_to "Open in Google Calendar", link_url,
@@ -130,7 +159,7 @@
       <% else %>
         <div class="alert alert-secondary">
           <i class="bi bi-info-circle me-1"></i>
-          Recorded only — connect Google Calendar (either party) to auto-schedule accepted matches.
+          Accepted — connect Google Calendar (either party) to get a smart slot picker for your next match.
         </div>
       <% end %>
     <% end %>

--- a/app/views/scheduling_mailer/confirmed.html.erb
+++ b/app/views/scheduling_mailer/confirmed.html.erb
@@ -1,0 +1,19 @@
+<p>Hi <%= @recipient.display_label %>,</p>
+
+<p>
+  Your meeting with <strong><%= @other&.display_label %></strong> has been confirmed for
+  <strong><%= @slot&.starts_at&.strftime("%A, %B %-d at %-I:%M %p %Z") %></strong>
+  (30 minutes).
+</p>
+
+<% link_url = @proposal.calendar_event_link.to_s %>
+<% if link_url.start_with?("https://") %>
+  <p style="text-align: center; margin: 24px 0;">
+    <%= link_to "Open in Google Calendar", link_url,
+          style: "background: #198754; color: #fff; padding: 12px 28px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;" %>
+  </p>
+<% end %>
+
+<div class="footer">
+  <p>Enjoy your conversation!</p>
+</div>

--- a/app/views/scheduling_mailer/confirmed.text.erb
+++ b/app/views/scheduling_mailer/confirmed.text.erb
@@ -1,0 +1,11 @@
+Hi <%= @recipient.display_label %>,
+
+Your meeting with <%= @other&.display_label %> has been confirmed for
+<%= @slot&.starts_at&.strftime("%A, %B %-d at %-I:%M %p %Z") %> (30 minutes).
+
+<% link_url = @proposal.calendar_event_link.to_s %>
+<% if link_url.start_with?("https://") %>
+Open in Google Calendar: <%= link_url %>
+<% end %>
+
+Enjoy your conversation!

--- a/app/views/scheduling_mailer/expired.html.erb
+++ b/app/views/scheduling_mailer/expired.html.erb
@@ -1,0 +1,12 @@
+<p>Hi <%= @recipient.display_label %>,</p>
+
+<p>
+  The 48-hour scheduling window for your intro meeting with
+  <strong><%= @other&.display_label %></strong> has expired without a slot being confirmed.
+</p>
+
+<p>You can run matchmaking again any time to get a new match.</p>
+
+<div class="footer">
+  <p>No action needed — this is just a notification.</p>
+</div>

--- a/app/views/scheduling_mailer/expired.text.erb
+++ b/app/views/scheduling_mailer/expired.text.erb
@@ -1,0 +1,5 @@
+Hi <%= @recipient.display_label %>,
+
+The 48-hour scheduling window for your intro meeting with <%= @other&.display_label %> has expired without a slot being confirmed.
+
+You can run matchmaking again any time to get a new match.

--- a/app/views/scheduling_mailer/invite.html.erb
+++ b/app/views/scheduling_mailer/invite.html.erb
@@ -1,0 +1,19 @@
+<p>Hi <%= @recipient.display_label %>,</p>
+
+<p>
+  Your AI secretary has matched you with <strong><%= @other&.display_label %></strong>.
+  Please pick a 30-minute time slot for your intro meeting — the window closes
+  <strong><%= @expires_at.strftime("%A, %B %-d at %-I:%M %p %Z") %></strong>.
+</p>
+
+<p style="text-align: center; margin: 24px 0;">
+  <%= link_to "Choose a time", @url,
+        style: "background: #0d6efd; color: #fff; padding: 12px 28px; text-decoration: none; border-radius: 6px; font-weight: 600; display: inline-block;" %>
+</p>
+
+<p>Or copy and paste this URL into your browser:</p>
+<p style="word-break: break-all; font-size: 13px; color: #6c757d;"><%= @url %></p>
+
+<div class="footer">
+  <p>If you don't pick a slot before the deadline, the scheduling window will expire and you can run matchmaking again.</p>
+</div>

--- a/app/views/scheduling_mailer/invite.text.erb
+++ b/app/views/scheduling_mailer/invite.text.erb
@@ -1,0 +1,8 @@
+Hi <%= @recipient.display_label %>,
+
+Your AI secretary has matched you with <%= @other&.display_label %>.
+Please pick a 30-minute time slot before <%= @expires_at.strftime("%A, %B %-d at %-I:%M %p %Z") %>.
+
+<%= @url %>
+
+If you don't pick a slot before the deadline, the scheduling window will expire and you can run matchmaking again.

--- a/app/views/scheduling_negotiations/show.html.erb
+++ b/app/views/scheduling_negotiations/show.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, "Choose a meeting time" %>
+
+<div class="row justify-content-center">
+  <div class="col-md-7">
+    <%= link_to matches_path, class: "btn btn-link btn-sm px-0 mb-2" do %>
+      <i class="bi bi-arrow-left me-1"></i>Back to Matches
+    <% end %>
+
+    <h1 class="h5 fw-bold mb-1">
+      <i class="bi bi-calendar2-check me-1"></i>Schedule your intro meeting
+    </h1>
+    <p class="text-muted small mb-4">
+      <%= @negotiation.requester.display_label %> &amp; <%= @negotiation.recipient.display_label %>
+    </p>
+
+    <% if @negotiation.confirmed? %>
+      <% slot = @negotiation.confirmed_slot %>
+      <div class="alert alert-success">
+        <i class="bi bi-calendar-check me-1"></i>
+        <strong>Meeting confirmed</strong> for
+        <%= slot&.starts_at&.in_time_zone(current_user.timezone)
+              &.strftime("%A, %B %-d at %-I:%M %p %Z") %>.
+        <% link_url = @negotiation.meeting_proposal.calendar_event_link.to_s %>
+        <% if link_url.start_with?("https://") %>
+          <%= link_to "Open in Google Calendar", link_url,
+                class: "alert-link ms-1", target: "_blank", rel: "noopener noreferrer" %>
+        <% end %>
+      </div>
+
+    <% elsif @negotiation.expired? %>
+      <div class="alert alert-secondary">
+        <i class="bi bi-clock-history me-1"></i>
+        The scheduling window expired. Run matchmaking again to get a new match.
+      </div>
+
+    <% else %>
+      <div class="alert alert-info d-flex align-items-center gap-2 py-2">
+        <i class="bi bi-info-circle"></i>
+        <span>
+          Pick any slot below. Either party can confirm — first click wins.
+          This window closes <strong><%= @negotiation.expires_at.in_time_zone(current_user.timezone)
+                                           .strftime("%A, %B %-d at %-I:%M %p %Z") %></strong>.
+        </span>
+      </div>
+
+      <div class="list-group mb-4">
+        <% @negotiation.scheduling_slots.order(:starts_at).each do |slot| %>
+          <% local = slot.starts_at.in_time_zone(current_user.timezone) %>
+          <%= button_to confirm_scheduling_negotiation_path(@negotiation, slot_id: slot.id),
+                method: :post,
+                class: "list-group-item list-group-item-action d-flex align-items-center justify-content-between py-3" do %>
+            <span>
+              <i class="bi bi-calendar-event me-2 text-primary"></i>
+              <span class="fw-semibold"><%= local.strftime("%A, %B %-d") %></span>
+              <span class="text-muted ms-2"><%= local.strftime("%-I:%M %p %Z") %></span>
+            </span>
+            <span class="badge bg-primary">Confirm this slot</span>
+          <% end %>
+        <% end %>
+      </div>
+
+      <p class="text-muted small text-center">
+        Times shown in your timezone (<%= current_user.timezone %>).
+        Both parties receive an email confirmation once a slot is chosen.
+      </p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,5 +54,9 @@ Rails.application.routes.draw do
   resources :tags,   only: %i[index update destroy]
   resources :blocks, only: %i[create destroy]
 
+  resources :scheduling_negotiations, only: %i[show] do
+    member { post :confirm }
+  end
+
   root "dashboard#index"
 end

--- a/db/migrate/20260608000001_create_scheduling_tables.rb
+++ b/db/migrate/20260608000001_create_scheduling_tables.rb
@@ -1,0 +1,23 @@
+class CreateSchedulingTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :scheduling_negotiations do |t|
+      t.integer  :meeting_proposal_id, null: false
+      t.integer  :status,              null: false, default: 0
+      t.datetime :expires_at,          null: false
+      t.timestamps
+    end
+    add_index :scheduling_negotiations, :meeting_proposal_id, unique: true
+    add_index :scheduling_negotiations, [ :status, :expires_at ]
+    add_foreign_key :scheduling_negotiations, :meeting_proposals
+
+    create_table :scheduling_slots do |t|
+      t.integer  :scheduling_negotiation_id, null: false
+      t.datetime :starts_at,                 null: false
+      t.integer  :confirmed_by_id
+      t.timestamps
+    end
+    add_index :scheduling_slots, :scheduling_negotiation_id
+    add_foreign_key :scheduling_slots, :scheduling_negotiations
+    add_foreign_key :scheduling_slots, :users, column: :confirmed_by_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_07_000002) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -142,6 +142,25 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_000002) do
     t.index ["tag_id"], name: "index_person_tags_on_tag_id"
   end
 
+  create_table "scheduling_negotiations", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "expires_at", null: false
+    t.integer "meeting_proposal_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["meeting_proposal_id"], name: "index_scheduling_negotiations_on_meeting_proposal_id", unique: true
+    t.index ["status", "expires_at"], name: "index_scheduling_negotiations_on_status_and_expires_at"
+  end
+
+  create_table "scheduling_slots", force: :cascade do |t|
+    t.integer "confirmed_by_id"
+    t.datetime "created_at", null: false
+    t.integer "scheduling_negotiation_id", null: false
+    t.datetime "starts_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["scheduling_negotiation_id"], name: "index_scheduling_slots_on_scheduling_negotiation_id"
+  end
+
   create_table "sessions", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at"
@@ -203,6 +222,9 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_07_000002) do
   add_foreign_key "person_facts", "people"
   add_foreign_key "person_tags", "people"
   add_foreign_key "person_tags", "tags"
+  add_foreign_key "scheduling_negotiations", "meeting_proposals"
+  add_foreign_key "scheduling_slots", "scheduling_negotiations"
+  add_foreign_key "scheduling_slots", "users", column: "confirmed_by_id"
   add_foreign_key "sessions", "users"
   add_foreign_key "tags", "users"
 end

--- a/lib/tasks/scheduling.rake
+++ b/lib/tasks/scheduling.rake
@@ -1,0 +1,6 @@
+namespace :scheduling do
+  desc "Expire scheduling negotiations whose 48-hour window has passed"
+  task expire: :environment do
+    ExpireSchedulingNegotiationsJob.perform_now
+  end
+end

--- a/spec/services/matchmaking/round_orchestrator_service_spec.rb
+++ b/spec/services/matchmaking/round_orchestrator_service_spec.rb
@@ -78,54 +78,32 @@ RSpec.describe Matchmaking::RoundOrchestratorService, type: :service do
     end
 
     context "when the requester has Google connected" do
-      let(:calendar)   { instance_double(GoogleCalendarService) }
-      let(:gcal_event) { double("gcal_event", id: "evt-1", html_link: "https://cal/evt-1") }
-
       before do
         create(:google_credential, user: requester)
         stub_pitch(pitch_for(target))
         stub_review(accepted: true)
-        allow(GoogleCalendarService).to receive(:new).with(requester).and_return(calendar)
-        allow(calendar).to receive(:busy_intervals).and_return([])
-        allow(GoogleCalendarService).to receive(:earliest_free_slot).and_return(Time.utc(2026, 6, 1, 15, 0))
-        allow(calendar).to receive(:push_user_meeting).and_return(gcal_event)
       end
 
-      it "hosts on the requester, adds the recipient as attendee, and records the event" do
-        expect(calendar).to receive(:push_user_meeting)
-          .with(hash_including(attendee_emails: [target.email]))
-          .and_return(gcal_event)
-
-        service.call
-
+      it "enqueues CreateSchedulingNegotiationJob instead of booking synchronously" do
+        expect { service.call }
+          .to have_enqueued_job(CreateSchedulingNegotiationJob)
         proposal = MeetingProposal.last
-        expect(proposal.calendar_created).to be(true)
-        expect(proposal.calendar_event_id).to eq("evt-1")
-        expect(proposal.calendar_event_link).to eq("https://cal/evt-1")
+        expect(proposal).to be_accepted
+        expect(proposal.calendar_created).to be(false)
       end
     end
 
     context "when only the recipient has Google connected" do
-      let(:calendar)   { instance_double(GoogleCalendarService) }
-      let(:gcal_event) { double("gcal_event", id: "evt-2", html_link: "https://cal/evt-2") }
-
       before do
         create(:google_credential, user: target)
         stub_pitch(pitch_for(target))
         stub_review(accepted: true)
-        allow(GoogleCalendarService).to receive(:new).with(target).and_return(calendar)
-        allow(calendar).to receive(:busy_intervals).and_return([])
-        allow(GoogleCalendarService).to receive(:earliest_free_slot).and_return(nil) # falls back to default slot
-        allow(calendar).to receive(:push_user_meeting).and_return(gcal_event)
       end
 
-      it "hosts on the recipient and adds the requester as attendee" do
-        expect(calendar).to receive(:push_user_meeting)
-          .with(hash_including(attendee_emails: [requester.email]))
-          .and_return(gcal_event)
-
-        service.call
-        expect(MeetingProposal.last.calendar_created).to be(true)
+      it "enqueues CreateSchedulingNegotiationJob for the accepted proposal" do
+        expect { service.call }
+          .to have_enqueued_job(CreateSchedulingNegotiationJob)
+        expect(MeetingProposal.last).to be_accepted
       end
     end
 


### PR DESCRIPTION
When a match is accepted and at least one party has Google Calendar connected, enqueue CreateSchedulingNegotiationJob which finds 3-5 free 30-min slots (merging both parties' busy intervals), creates a SchedulingNegotiation with a 48-hour expiry window, and emails both parties to choose. Either party can confirm a slot at /scheduling_negotiations/:id; on confirmation the calendar event is booked and both parties receive a confirmation email. An expire job (rake scheduling:expire) marks stale negotiations and emails both parties. Proposals with no calendar connected remain record-only.