### PR TITLE
Add Claude Code GitHub Action workflow

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,33 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    # Only run when "@claude" appears in the comment or issue body
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/claude.yml` so `@claude` mentions in issues and PR comments trigger `anthropics/claude-code-action@v1` to analyze context and open PRs — the Claude equivalent of GitHub Copilot's coding agent (Milestone 4).

- Triggers on `@claude` in issue/PR comments and on issue open/assign (gated by an `if` so it only runs when `@claude` is present).
- Authenticates with the existing `CLAUDE_CODE_OAUTH_TOKEN` secret (Pro/Max subscription) — no paid API key required.
- Grants `contents`/`pull-requests`/`issues: write` + `id-token: write` so Claude can push branches and open PRs.

Must land on the default branch (`main`) before the events will trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
