### PR TITLE
Milestone 4 polish: accessibility, signup validation, tunable recency window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,8 @@
 /yarn-error.log
 
 CLAUDE.md
-git 
+git
+
+# Personal milestone files (not for the repo).
+/milestone3-checklist.md
+/Spring 26 Milestone 4 and final exam presentation.md

--- a/app/models/meeting_proposal.rb
+++ b/app/models/meeting_proposal.rb
@@ -18,9 +18,10 @@
 #   calendar_created          :boolean not null  default false
 class MeetingProposal < ApplicationRecord
   # Don't pitch the same ordered pair again within this window (anti-spam).
-  # DEV VALUE: shortened to 10 seconds so matchmaking can be re-run back-to-back
-  # while developing. Bump this back up (e.g. 30.days) before/when going to production.
-  RECENCY_WINDOW = 10.seconds
+  # Tunable via the MATCHMAKING_RECENCY_WINDOW_SECONDS env var so the window can be
+  # widened in production or kept short for live demos (the default lets matchmaking
+  # be re-run back-to-back).
+  RECENCY_WINDOW = ENV.fetch("MATCHMAKING_RECENCY_WINDOW_SECONDS", 10).to_i.seconds
 
   belongs_to :requester, class_name: "User"
   belongs_to :recipient, class_name: "User", optional: true

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -114,11 +114,11 @@
         <table class="table table-hover align-middle">
           <thead class="table-light">
             <tr>
-              <th>Date</th>
-              <th>Title</th>
-              <th>Medium</th>
-              <th>Participants</th>
-              <th></th>
+              <th scope="col">Date</th>
+              <th scope="col">Title</th>
+              <th scope="col">Medium</th>
+              <th scope="col">Participants</th>
+              <th scope="col"><span class="visually-hidden">Actions</span></th>
             </tr>
           </thead>
           <tbody>

--- a/app/views/people/index.html.erb
+++ b/app/views/people/index.html.erb
@@ -118,10 +118,10 @@ end %>
       <table class="table table-row-cards mb-0 align-middle">
         <thead>
           <tr>
-            <th><%= sort_link.call("name", "Name", icon: "bi-person") %></th>
-            <th class="text-end"><%= sort_link.call("frequency", "Catch up every", icon: "bi-arrow-repeat") %></th>
-            <th><%= sort_link.call("status", "Due", icon: "bi-clock-history") %></th>
-            <th style="width: 1%;"></th>
+            <th scope="col"><%= sort_link.call("name", "Name", icon: "bi-person") %></th>
+            <th scope="col" class="text-end"><%= sort_link.call("frequency", "Catch up every", icon: "bi-arrow-repeat") %></th>
+            <th scope="col"><%= sort_link.call("status", "Due", icon: "bi-clock-history") %></th>
+            <th scope="col" style="width: 1%;"><span class="visually-hidden">Actions</span></th>
           </tr>
         </thead>
         <tbody>

--- a/app/views/registrations/new.html.erb
+++ b/app/views/registrations/new.html.erb
@@ -109,7 +109,7 @@
                   Intl.DateTimeFormat().resolvedOptions().timeZone;
               </script>
               <div class="form-check">
-                <%= f.check_box :terms_accepted, class: "form-check-input" %>
+                <%= f.check_box :terms_accepted, class: "form-check-input", required: true %>
                 <%= f.label :terms_accepted, class: "form-check-label" do %>
                   I agree to the <%= link_to "Terms of Service", terms_path, target: "_blank" %>
                 <% end %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -15,7 +15,7 @@
         <label class="form-label fw-semibold">Profile photo</label>
         <div class="d-flex align-items-center gap-3 mb-2">
           <% if current_user.avatar.attached? %>
-            <%= image_tag current_user.avatar, class: "avatar avatar-xl rounded-circle", style: "object-fit:cover;" %>
+            <%= image_tag current_user.avatar, class: "avatar avatar-xl rounded-circle", style: "object-fit:cover;", alt: "#{current_user.display_label}'s profile photo" %>
           <% else %>
             <% initials = current_user.display_label.split.first(2).map { |w| w[0].upcase }.join %>
             <span class="avatar avatar-xl" style="background:#4F46E5;color:#fff;"><%= initials %></span>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -26,7 +26,7 @@
       <%= image_tag "serendipity-mark.svg", height: 22, alt: "" %>
       <span class="fw-bold text-white" style="font-size:0.9rem;">Serendipity</span>
     </span>
-    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas"></button>
+    <button type="button" class="btn-close btn-close-white" data-bs-dismiss="offcanvas" aria-label="Close menu"></button>
   </div>
   <div class="offcanvas-body d-flex flex-column p-0">
     <% if authenticated? %>
@@ -104,7 +104,7 @@
     <div class="sidebar-footer">
       <div class="d-flex align-items-center gap-2">
         <% if current_user.avatar.attached? %>
-          <%= image_tag current_user.avatar, class: "avatar rounded-circle flex-shrink-0", style: "object-fit:cover;" %>
+          <%= image_tag current_user.avatar, class: "avatar rounded-circle flex-shrink-0", style: "object-fit:cover;", alt: "#{current_user.display_label}'s profile photo" %>
         <% else %>
           <% nav_initials = current_user.display_label.split.first(2).map { |w| w[0].upcase }.join %>
           <span class="avatar flex-shrink-0" style="background:#4F46E5;color:#fff;font-size:0.7rem;"><%= nav_initials %></span>


### PR DESCRIPTION
Small Milestone 4 cleanup pass. No behavioral changes for end users beyond the noted accessibility/validation improvements.

## Changes
- **Accessibility (req 11)**
  - `scope="col"` on the People and Events table headers; the actions column header is now labeled for screen readers (`visually-hidden` "Actions").
  - Descriptive `alt` text on the user avatar images in the navbar and settings page.
  - `aria-label="Close menu"` on the mobile offcanvas close button.
- **Signup validation (req 6)**
  - `required` attribute on the Terms of Service checkbox so the client blocks submission, matching the existing server-side `acceptance: true` validation.
- **Config cleanup (req 2)**
  - `MeetingProposal::RECENCY_WINDOW` is now env-tunable via `MATCHMAKING_RECENCY_WINDOW_SECONDS`, keeping the demo-friendly 10s default. This removes the leftover "DEV VALUE — bump before production" comment while keeping matchmaking re-runnable back-to-back for live demos. No behavioral change with the default.
- **Repo hygiene**
  - gitignore the local Milestone 4 doc and milestone checklists.

## Verification
- `bundle exec rubocop` — clean
- `bundle exec erb_lint` — no errors
- `bundle exec rspec` — 231 examples, 0 failures
- `bundle exec cucumber` — 21 scenarios / 138 steps, all pass (including the "register without accepting terms" sad path, confirming the new `required` attribute does not break the server-side fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
