### PR TITLE
Add PWA push notifications for overdue contacts and birthdays issue 182

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,12 @@ GOOGLE_REDIRECT_URI=http://localhost:3000/google/oauth/callback
 # ── OpenRouter AI (reconnect message suggestions) ───────────────────────────
 # Get a free API key at https://openrouter.ai/
 OPENROUTER_API_KEY=your-openrouter-api-key
+
+# ── Web Push / PWA push notifications ───────────────────────────────────────
+# Generate a VAPID key pair once with:
+#   bundle exec ruby -e "require 'webpush'; k=Webpush.generate_key; puts 'VAPID_PUBLIC_KEY='+k.public_key; puts 'VAPID_PRIVATE_KEY='+k.private_key"
+# Then set these values here (dev) and as Heroku config vars (prod).
+# VAPID_CONTACT_EMAIL is shown to browser vendors; use a real address.
+VAPID_PUBLIC_KEY=your-vapid-public-key
+VAPID_PRIVATE_KEY=your-vapid-private-key
+VAPID_CONTACT_EMAIL=hello@example.com

--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem "pagy", "~> 9.3"
 gem "google-apis-calendar_v3", "~> 0.17"
 gem "googleauth", "~> 1.11"
 
+# Web Push notifications (VAPID signing)
+gem "webpush", "~> 1.1"
+
 gem "dotenv-rails", "~> 3.2", groups: [:development, :test]
 
 # OpenAI-compatible client for AI message generation via OpenRouter

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,7 @@ GEM
       signet (>= 0.16, < 2.a)
     groupdate (6.8.0)
       activesupport (>= 7.2)
+    hkdf (0.3.0)
     i18n (1.14.8)
       concurrent-ruby (~> 1.0)
     importmap-rails (2.2.3)
@@ -244,7 +245,7 @@ GEM
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
     json (2.19.4)
-    jwt (3.2.0)
+    jwt (2.10.3)
       base64
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
@@ -483,6 +484,9 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
+    webpush (1.1.0)
+      hkdf (~> 0.2)
+      jwt (~> 2.0)
     websocket-driver (0.8.0)
       base64
       websocket-extensions (>= 0.1.0)
@@ -543,6 +547,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webpush (~> 1.1)
 
 CHECKSUMS
   action_text-trix (2.1.18) sha256=3fdb83f8bff4145d098be283cdd47ac41caf5110bfa6df4695ed7127d7fb3642
@@ -622,13 +627,14 @@ CHECKSUMS
   google-logging-utils (0.2.0) sha256=675462b4ea5affa825a3442694ca2d75d0069455a1d0956127207498fca3df7b
   googleauth (1.16.2) sha256=15009502e2e38af71948cda918f230e27d327f6882a1e47967a5a4664930a638
   groupdate (6.8.0) sha256=16f90ea18ca981c38e41e592416480b28353aa5e5cc3e7cb13a68b8fb5d40510
+  hkdf (0.3.0) sha256=34c62c7708451aaccbbafde62c471d837aa174dc30302381dfc486a2c0ebd111
   i18n (1.14.8) sha256=285778639134865c5e0f6269e0b818256017e8cde89993fdfcbfb64d088824a5
   importmap-rails (2.2.3) sha256=7101be2a4dc97cf1558fb8f573a718404c5f6bcfe94f304bf1f39e444feeb16a
   iniparse (1.5.0) sha256=36a165e98d8a250b7631c4a7f9afba32af78f089970cd6446a39771189c761f1
   io-console (0.8.2) sha256=d6e3ae7a7cc7574f4b8893b4fca2162e57a825b223a177b7afa236c5ef9814cc
   irb (1.17.0) sha256=168c4ddb93d8a361a045c41d92b2952c7a118fa73f23fe14e55609eb7a863aae
   json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
-  jwt (3.2.0) sha256=5419b1fe37b1da0982bd07051f573a8b8789ab724c2aa7e785e4784a3ed217d7
+  jwt (2.10.3) sha256=e4d9352fbc7309b1a7448c7dd713dfe4d8c47077af80759cdbed8f878ea0b484
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
@@ -736,6 +742,7 @@ CHECKSUMS
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   web-console (4.3.0) sha256=e13b71301cdfc2093f155b5aa3a622db80b4672d1f2f713119cc7ec7ac6a6da4
+  webpush (1.1.0) sha256=63773d1e5cd06c45e34bf1641fd530b9f328b2de2bc46708ff0c200c505135fd
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241
   xpath (3.2.0) sha256=6dfda79d91bb3b949b947ecc5919f042ef2f399b904013eb3ef6d20dd3a4082e

--- a/app/controllers/push_subscriptions_controller.rb
+++ b/app/controllers/push_subscriptions_controller.rb
@@ -1,0 +1,17 @@
+class PushSubscriptionsController < ApplicationController
+  def create
+    data = JSON.parse(request.body.read)
+    current_user.push_subscriptions.find_or_create_by!(endpoint: data["endpoint"]) do |sub|
+      sub.p256dh_key = data.dig("keys", "p256dh")
+      sub.auth_key   = data.dig("keys", "auth")
+    end
+    head :created
+  rescue JSON::ParserError, ActionController::ParameterMissing
+    head :unprocessable_entity
+  end
+
+  def destroy
+    current_user.push_subscriptions.find_by(endpoint: params[:endpoint])&.destroy
+    head :no_content
+  end
+end

--- a/app/jobs/nudge_notification_job.rb
+++ b/app/jobs/nudge_notification_job.rb
@@ -1,0 +1,96 @@
+class NudgeNotificationJob < ApplicationJob
+  queue_as :default
+
+  # Only nudge for contacts this many days overdue (avoids spamming on every run).
+  OVERDUE_THRESHOLD_DAYS = 7
+  # Warn about birthdays this many days in advance.
+  BIRTHDAY_LOOKAHEAD_DAYS = 7
+  # Cap notifications per user per run to avoid overwhelming them.
+  MAX_NUDGES_PER_USER = 3
+
+  def perform
+    return if vapid_keys_missing?
+
+    User.find_each do |user|
+      next if user.push_subscriptions.none?
+      send_nudges(user)
+    rescue StandardError => e
+      Rails.logger.warn("NudgeNotificationJob: user #{user.id}: #{e.message}")
+    end
+  end
+
+  private
+
+  def send_nudges(user)
+    nudges = overdue_nudges(user) + birthday_nudges(user)
+    nudges.first(MAX_NUDGES_PER_USER).each do |payload|
+      user.push_subscriptions.each do |sub|
+        deliver(sub, payload)
+      rescue Webpush::InvalidSubscription, Webpush::ExpiredSubscription
+        sub.destroy
+      rescue StandardError => e
+        Rails.logger.warn("NudgeNotificationJob: push to sub #{sub.id} failed: #{e.message}")
+      end
+    end
+  end
+
+  def overdue_nudges(user)
+    user.people
+        .includes(:events)
+        .reject(&:snoozed?)
+        .filter_map do |person|
+          days = person.days_until_due
+          next unless days && days <= -OVERDUE_THRESHOLD_DAYS
+          weeks_overdue = (-days / 7.0).round
+          {
+            title: "Time to reach out",
+            body:  "You haven't talked to #{person.name} in #{weeks_overdue} #{"week".pluralize(weeks_overdue)}.",
+            url:   "/people/#{person.id}"
+          }
+        end
+        .sort_by { |n| n[:body] }
+  end
+
+  def birthday_nudges(user)
+    today = Date.current
+    user.people
+        .includes(:events)
+        .filter_map do |person|
+          next unless person.birthday.present?
+          days = days_until_birthday(person.birthday, today)
+          next unless days && days <= BIRTHDAY_LOOKAHEAD_DAYS && days >= 0
+          label = days == 0 ? "today" : "in #{days} #{"day".pluralize(days)}"
+          {
+            title: "Upcoming birthday",
+            body:  "#{person.name}'s birthday is #{label}.",
+            url:   "/people/#{person.id}"
+          }
+        end
+  end
+
+  # Returns days until next birthday occurrence from today (0 = today, 1 = tomorrow …).
+  def days_until_birthday(birthday, today)
+    this_year = birthday.change(year: today.year)
+    candidate = this_year < today ? this_year.next_year : this_year
+    (candidate - today).to_i
+  end
+
+  def deliver(subscription, payload)
+    Webpush.payload_send(
+      message:     JSON.generate(payload),
+      endpoint:    subscription.endpoint,
+      p256dh:      subscription.p256dh_key,
+      auth:        subscription.auth_key,
+      vapid:       {
+        subject:     "mailto:#{ENV.fetch("VAPID_CONTACT_EMAIL", "hello@example.com")}",
+        public_key:  ENV.fetch("VAPID_PUBLIC_KEY"),
+        private_key: ENV.fetch("VAPID_PRIVATE_KEY")
+      },
+      ttl: 24 * 60 * 60
+    )
+  end
+
+  def vapid_keys_missing?
+    ENV["VAPID_PUBLIC_KEY"].blank? || ENV["VAPID_PRIVATE_KEY"].blank?
+  end
+end

--- a/app/models/push_subscription.rb
+++ b/app/models/push_subscription.rb
@@ -1,0 +1,14 @@
+class PushSubscription < ApplicationRecord
+  belongs_to :user
+
+  validates :endpoint,   presence: true, uniqueness: true
+  validates :p256dh_key, presence: true
+  validates :auth_key,   presence: true
+
+  def to_webpush_subscription
+    {
+      endpoint:  endpoint,
+      keys:      { p256dh: p256dh_key, auth: auth_key }
+    }
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,8 @@ class User < ApplicationRecord
   has_many :blocked_users,  through: :blocks, source: :blocked
   has_many :reverse_blocks, class_name: "Block", foreign_key: :blocked_id, dependent: :destroy
 
+  has_many :push_subscriptions, dependent: :destroy
+
   def blocking?(user)
     blocks.exists?(blocked: user)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,6 +8,9 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    <% if ENV["VAPID_PUBLIC_KEY"].present? %>
+      <meta name="vapid-public-key" content="<%= ENV["VAPID_PUBLIC_KEY"] %>">
+    <% end %>
 
     <%= yield :head %>
 
@@ -65,9 +68,44 @@
       integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
       crossorigin="anonymous"></script>
     <script>
-      if ("serviceWorker" in navigator) {
-        navigator.serviceWorker.register("/service-worker.js", { scope: "/" });
-      }
+      (function () {
+        if (!("serviceWorker" in navigator)) return;
+
+        navigator.serviceWorker.register("/service-worker.js", { scope: "/" }).then(function (reg) {
+          var publicKey = document.querySelector("meta[name='vapid-public-key']");
+          if (!publicKey || !("PushManager" in window)) return;
+
+          reg.pushManager.getSubscription().then(function (existing) {
+            if (existing) return;
+            Notification.requestPermission().then(function (permission) {
+              if (permission !== "granted") return;
+              reg.pushManager.subscribe({
+                userVisibleOnly: true,
+                applicationServerKey: urlBase64ToUint8Array(publicKey.content)
+              }).then(function (sub) {
+                var data = sub.toJSON();
+                fetch("/push_subscriptions", {
+                  method: "POST",
+                  headers: {
+                    "Content-Type": "application/json",
+                    "X-CSRF-Token": document.querySelector("meta[name='csrf-token']").content
+                  },
+                  body: JSON.stringify(data)
+                });
+              });
+            });
+          });
+        });
+
+        function urlBase64ToUint8Array(base64String) {
+          var padding = "=".repeat((4 - base64String.length % 4) % 4);
+          var base64 = (base64String + padding).replace(/-/g, "+").replace(/_/g, "/");
+          var raw = atob(base64);
+          var output = new Uint8Array(raw.length);
+          for (var i = 0; i < raw.length; i++) { output[i] = raw.charCodeAt(i); }
+          return output;
+        }
+      })();
     </script>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -52,7 +52,8 @@ Rails.application.routes.draw do
   end
   resources :events
   resources :tags,   only: %i[index update destroy]
-  resources :blocks, only: %i[create destroy]
+  resources :blocks,              only: %i[create destroy]
+  resources :push_subscriptions,  only: %i[create destroy]
 
   resources :scheduling_negotiations, only: %i[show] do
     member { post :confirm }

--- a/db/migrate/20260608000002_create_push_subscriptions.rb
+++ b/db/migrate/20260608000002_create_push_subscriptions.rb
@@ -1,0 +1,14 @@
+class CreatePushSubscriptions < ActiveRecord::Migration[8.1]
+  def change
+    create_table :push_subscriptions do |t|
+      t.integer :user_id, null: false
+      t.text    :endpoint, null: false
+      t.string  :p256dh_key, null: false
+      t.string  :auth_key,   null: false
+      t.timestamps
+    end
+    add_index :push_subscriptions, :user_id
+    add_index :push_subscriptions, :endpoint, unique: true
+    add_foreign_key :push_subscriptions, :users
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_000002) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -142,6 +142,17 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_000001) do
     t.index ["tag_id"], name: "index_person_tags_on_tag_id"
   end
 
+  create_table "push_subscriptions", force: :cascade do |t|
+    t.string "auth_key", null: false
+    t.datetime "created_at", null: false
+    t.text "endpoint", null: false
+    t.string "p256dh_key", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id", null: false
+    t.index ["endpoint"], name: "index_push_subscriptions_on_endpoint", unique: true
+    t.index ["user_id"], name: "index_push_subscriptions_on_user_id"
+  end
+
   create_table "scheduling_negotiations", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "expires_at", null: false
@@ -222,6 +233,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_000001) do
   add_foreign_key "person_facts", "people"
   add_foreign_key "person_tags", "people"
   add_foreign_key "person_tags", "tags"
+  add_foreign_key "push_subscriptions", "users"
   add_foreign_key "scheduling_negotiations", "meeting_proposals"
   add_foreign_key "scheduling_slots", "scheduling_negotiations"
   add_foreign_key "scheduling_slots", "users", column: "confirmed_by_id"

--- a/lib/tasks/nudges.rake
+++ b/lib/tasks/nudges.rake
@@ -1,0 +1,6 @@
+namespace :nudges do
+  desc "Send push notifications for overdue contacts and upcoming birthdays"
+  task push: :environment do
+    NudgeNotificationJob.perform_now
+  end
+end

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -15,3 +15,27 @@ self.addEventListener("fetch", (event) => {
   if (event.request.method !== "GET") return;
   event.respondWith(fetch(event.request).catch(() => caches.match(event.request)));
 });
+
+self.addEventListener("push", (event) => {
+  let data = {};
+  try { data = event.data ? event.data.json() : {}; } catch (_) {}
+  const title = data.title || "Serendipity";
+  const options = {
+    body:  data.body || "",
+    icon:  "/icon.png",
+    badge: "/icon.png",
+    data:  { url: data.url || "/" }
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url || "/";
+  event.waitUntil(
+    clients.matchAll({ type: "window", includeUncontrolled: true }).then((cs) => {
+      const existing = cs.find((c) => c.url.endsWith(url));
+      return existing ? existing.focus() : clients.openWindow(url);
+    })
+  );
+});


### PR DESCRIPTION
Adds web push support using VAPID signing (webpush gem). On first load the app requests notification permission and stores the browser's push subscription. NudgeNotificationJob (rake nudges:push) fires for every user with subscriptions: contacts 7+ days overdue get a reach-out nudge, and contacts with a birthday in the next 7 days get a birthday reminder (capped at 3 nudges per user per run). The service worker handles push display and taps open the relevant contact page. VAPID keys are loaded from env vars documented in .env.example.