### PR TITLE
Add multi-user shared contacts issue 180

### DIFF
--- a/app/controllers/contact_links_controller.rb
+++ b/app/controllers/contact_links_controller.rb
@@ -1,0 +1,47 @@
+class ContactLinksController < ApplicationController
+  def create
+    other_user = User.find_by(email: params[:other_user_email].to_s.strip.downcase)
+    unless other_user && other_user != current_user
+      return redirect_to person_path(params[:person_id]),
+        alert: "No other Serendipity user found with that email."
+    end
+
+    my_person = current_user.people.find(params[:person_id])
+    their_person = other_user.people.find_by(email: my_person.email)
+    unless their_person
+      return redirect_to person_path(my_person),
+        alert: "#{other_user.display_label} doesn't have #{my_person.name} (#{my_person.email}) in their contacts yet."
+    end
+
+    link = ContactLink.new(requester_person: my_person, recipient_person: their_person)
+    if link.save
+      redirect_to person_path(my_person),
+        notice: "Invite sent to #{other_user.display_label}. They'll see it when they view #{my_person.name}."
+    else
+      redirect_to person_path(my_person), alert: link.errors.full_messages.to_sentence
+    end
+  rescue ActiveRecord::RecordNotFound
+    redirect_to people_path, alert: "Contact not found."
+  end
+
+  def update
+    link = ContactLink.find(params[:id])
+    return redirect_to people_path, alert: "Not authorized." unless link.recipient_person.user == current_user
+
+    link.accepted!
+    redirect_to person_path(link.recipient_person),
+      notice: "Linked with #{link.requester_person.user.display_label}'s record. You'll now see shared history."
+  end
+
+  def destroy
+    link = ContactLink.find(params[:id])
+    parties = [ link.requester_person.user, link.recipient_person.user ]
+    return redirect_to people_path, alert: "Not authorized." unless parties.include?(current_user)
+
+    my_person = current_user == link.requester_person.user ? link.requester_person : link.recipient_person
+    link.destroy
+    redirect_to person_path(my_person), notice: "Contact link removed."
+  rescue ActiveRecord::RecordNotFound
+    redirect_to people_path, alert: "Link not found."
+  end
+end

--- a/app/controllers/people_controller.rb
+++ b/app/controllers/people_controller.rb
@@ -46,6 +46,15 @@ class PeopleController < ApplicationController
   def show
     @events = @person.events.recent
     @facts  = @person.person_facts.order(created_at: :desc)
+    @contact_link  = @person.contact_link
+    @linked_person = @person.linked_person
+    @shared_events = if @linked_person
+      Event.joins(:event_participants)
+           .where(event_participants: { person_id: [@person.id, @linked_person.id] })
+           .includes(:user, :people)
+           .distinct
+           .order(occurred_at: :desc)
+    end
     @suggested_times = if current_user.google_calendar_connected?
       GoogleCalendarService.new(current_user).suggest_times(@person)
     else

--- a/app/models/contact_link.rb
+++ b/app/models/contact_link.rb
@@ -1,0 +1,32 @@
+class ContactLink < ApplicationRecord
+  belongs_to :requester_person, class_name: "Person"
+  belongs_to :recipient_person, class_name: "Person"
+
+  enum :status, { pending: 0, accepted: 1, declined: 2 }
+
+  validate :persons_belong_to_different_users
+  validate :persons_not_already_linked, on: :create
+
+  def other_person(person)
+    person.id == requester_person_id ? recipient_person : requester_person
+  end
+
+  private
+
+  def persons_belong_to_different_users
+    return if requester_person.nil? || recipient_person.nil?
+    if requester_person.user_id == recipient_person.user_id
+      errors.add(:base, "cannot link two contacts belonging to the same user")
+    end
+  end
+
+  def persons_not_already_linked
+    return if requester_person.nil? || recipient_person.nil?
+    if requester_person.contact_link.present?
+      errors.add(:base, "#{requester_person.name} is already in a shared contact link")
+    end
+    if recipient_person.contact_link.present?
+      errors.add(:base, "#{recipient_person.name} is already in a shared contact link")
+    end
+  end
+end

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -24,6 +24,8 @@ class Person < ApplicationRecord
   has_many :tags, through: :person_tags
   has_many :person_facts,   dependent: :destroy
   has_many :outreach_drafts, dependent: :destroy
+  has_one :sent_link,     class_name: "ContactLink", foreign_key: :requester_person_id, dependent: :destroy, inverse_of: :requester_person
+  has_one :received_link, class_name: "ContactLink", foreign_key: :recipient_person_id, dependent: :destroy, inverse_of: :recipient_person
 
   scope :favorites, -> { where(favorite: true) }
 
@@ -83,6 +85,16 @@ class Person < ApplicationRecord
       count += 1
     end
     count
+  end
+
+  def contact_link
+    sent_link || received_link
+  end
+
+  def linked_person
+    link = contact_link
+    return nil unless link&.accepted?
+    link.other_person(self)
   end
 
   # The registered User account (if any) that shares this contact's email.

--- a/app/views/people/show.html.erb
+++ b/app/views/people/show.html.erb
@@ -11,6 +11,44 @@
 <% p_start   = person_tz.local(today.year, today.month, today.day, @person.preferred_start_hour) %>
 <% p_end     = person_tz.local(today.year, today.month, today.day, @person.preferred_end_hour) %>
 
+<%# ── Shared-contact banners ───────────────────────────────── %>
+<% if @contact_link&.pending? && @contact_link.recipient_person == @person %>
+  <div class="alert alert-info d-flex align-items-center gap-3 mb-4 flex-wrap">
+    <i class="bi bi-person-plus-fill fs-4 flex-shrink-0"></i>
+    <div class="flex-grow-1">
+      <strong><%= @contact_link.requester_person.user.display_label %></strong>
+      invited you to share contact history for <strong><%= @person.name %></strong>.
+      You'll both see a combined event timeline.
+    </div>
+    <div class="d-flex gap-2 ms-auto flex-shrink-0">
+      <%= button_to "Accept", contact_link_path(@contact_link), method: :patch,
+            class: "btn btn-sm btn-primary" %>
+      <%= button_to "Decline", contact_link_path(@contact_link), method: :delete,
+            class: "btn btn-sm btn-outline-secondary",
+            form: { data: { turbo_confirm: "Decline the shared-contact invite?" } } %>
+    </div>
+  </div>
+<% elsif @contact_link&.pending? && @contact_link.requester_person == @person %>
+  <div class="alert alert-secondary d-flex align-items-center gap-3 mb-4 flex-wrap">
+    <i class="bi bi-hourglass-split flex-shrink-0"></i>
+    <div class="flex-grow-1">
+      Invite sent to <strong><%= @contact_link.recipient_person.user.display_label %></strong> — waiting for them to accept.
+    </div>
+    <%= button_to "Cancel invite", contact_link_path(@contact_link), method: :delete,
+          class: "btn btn-sm btn-outline-danger ms-auto flex-shrink-0" %>
+  </div>
+<% elsif @contact_link&.accepted? %>
+  <div class="alert alert-success d-flex align-items-center gap-3 mb-4 flex-wrap">
+    <i class="bi bi-people-fill flex-shrink-0"></i>
+    <div class="flex-grow-1">
+      Shared with <strong><%= @linked_person.user.display_label %></strong> — combined history shown below.
+    </div>
+    <%= button_to "Unlink", contact_link_path(@contact_link), method: :delete,
+          class: "btn btn-sm btn-outline-danger ms-auto flex-shrink-0",
+          form: { data: { turbo_confirm: "Unlink shared contact? Each user will only see their own events again." } } %>
+  </div>
+<% end %>
+
 <div class="d-flex align-items-center gap-2 mb-4">
   <%= link_to people_path, class: "btn-back" do %>
     <i class="bi bi-arrow-left"></i>
@@ -184,37 +222,47 @@
   </div>
 <% end %>
 
-<%# ── Recent events ────────────────────────────────────────── %>
+<%# ── History (own or shared) ───────────────────────────────── %>
 <div class="d-flex justify-content-between align-items-center mb-3">
-  <h2 class="h5 mb-0 fw-bold">History</h2>
+  <h2 class="h5 mb-0 fw-bold"><%= @linked_person ? "Shared History" : "History" %></h2>
   <%= link_to "Log Event with #{@person.name}", new_event_path(person_id: @person.id), class: "btn btn-sm btn-primary" %>
 </div>
 
-<% if @events.empty? %>
+<% display_events = @shared_events || @events %>
+<% if display_events.empty? %>
   <p class="text-muted">No events logged yet with <%= @person.name %>.</p>
 <% else %>
-  <% latest = @person.latest_event %>
-  <% days_ago = ((Time.current - latest.occurred_at) / 1.day).round %>
+  <% latest_event = display_events.first %>
+  <% days_ago = ((Time.current - latest_event.occurred_at) / 1.day).round %>
   <p class="text-muted small mb-3">
     Last caught up <strong><%= days_ago %> day<%= "s" unless days_ago == 1 %> ago</strong>
-    via <span class="badge <%= medium_badge_class(latest.medium) %>"><%= latest.medium.titleize %></span>
+    via <span class="badge <%= medium_badge_class(latest_event.medium) %>"><%= latest_event.medium.titleize %></span>
   </p>
 
   <div class="event-timeline">
-    <% @events.each do |event| %>
+    <% display_events.each do |event| %>
       <div class="event-timeline-item">
         <div class="event-timeline-dot" style="background: <%= color %>;"></div>
         <div class="event-timeline-body card">
           <div class="card-body py-3 px-3">
             <div class="d-flex justify-content-between align-items-start gap-2">
               <div>
-                <%= link_to event.display_title, event_path(event), class: "fw-semibold text-decoration-none text-dark" %>
+                <% if event.user == current_user %>
+                  <%= link_to event.display_title, event_path(event), class: "fw-semibold text-decoration-none text-dark" %>
+                <% else %>
+                  <span class="fw-semibold"><%= event.display_title %></span>
+                <% end %>
                 <span class="badge <%= medium_badge_class(event.medium) %> ms-1"><%= event.medium.titleize %></span>
+                <% if @linked_person %>
+                  <span class="badge bg-light text-muted border ms-1">
+                    <%= event.user == current_user ? "you" : @linked_person.user.display_label %>
+                  </span>
+                <% end %>
                 <div class="text-muted small mt-1"><%= l event.occurred_at, format: :long %></div>
-                <% others = event.people - [@person] %>
+                <% others = event.people - [@person, @linked_person].compact %>
                 <% if others.any? %>
                   <div class="text-muted small">
-                    with <%= safe_join(others.map { |p| link_to p.name, person_path(p), class: "text-decoration-none" }, ", ") %>
+                    with <%= safe_join(others.map { |p| p.user == current_user ? link_to(p.name, person_path(p), class: "text-decoration-none") : p.name }, ", ") %>
                   </div>
                 <% end %>
               </div>
@@ -223,5 +271,31 @@
         </div>
       </div>
     <% end %>
+  </div>
+<% end %>
+
+<%# ── Share this contact ────────────────────────────────────── %>
+<% unless @contact_link %>
+  <div class="card mt-4 mb-4">
+    <div class="card-body">
+      <h2 class="h6 fw-semibold mb-2">
+        <i class="bi bi-share me-1"></i>Share this contact
+      </h2>
+      <p class="text-muted small mb-3">
+        If another Serendipity user also knows <%= @person.name %>, link your records to see a
+        combined history and co-own nudge responsibility.
+      </p>
+      <%= form_with url: contact_links_path, method: :post, local: true do |f| %>
+        <%= f.hidden_field :person_id, value: @person.id %>
+        <div class="d-flex gap-2">
+          <%= f.email_field :other_user_email,
+                placeholder: "Their Serendipity account email",
+                class: "form-control form-control-sm",
+                required: true,
+                autocomplete: "off" %>
+          <%= f.submit "Send invite", class: "btn btn-sm btn-outline-primary flex-shrink-0" %>
+        </div>
+      <% end %>
+    </div>
   </div>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,6 +55,8 @@ Rails.application.routes.draw do
   resources :blocks,              only: %i[create destroy]
   resources :push_subscriptions,  only: %i[create destroy]
 
+  resources :contact_links, only: %i[create update destroy]
+
   resources :scheduling_negotiations, only: %i[show] do
     member { post :confirm }
   end

--- a/db/migrate/20260608000004_create_contact_links.rb
+++ b/db/migrate/20260608000004_create_contact_links.rb
@@ -1,0 +1,15 @@
+class CreateContactLinks < ActiveRecord::Migration[8.1]
+  def change
+    create_table :contact_links do |t|
+      t.integer :requester_person_id, null: false
+      t.integer :recipient_person_id, null: false
+      t.integer :status, null: false, default: 0
+      t.timestamps
+    end
+    # Each person record can participate in at most one link (either side).
+    add_index :contact_links, :requester_person_id, unique: true
+    add_index :contact_links, :recipient_person_id, unique: true
+    add_foreign_key :contact_links, :people, column: :requester_person_id
+    add_foreign_key :contact_links, :people, column: :recipient_person_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_08_000003) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_08_000004) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -46,6 +46,16 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_000003) do
     t.datetime "updated_at", null: false
     t.index ["blocked_id"], name: "index_blocks_on_blocked_id"
     t.index ["blocker_id", "blocked_id"], name: "index_blocks_on_blocker_id_and_blocked_id", unique: true
+  end
+
+  create_table "contact_links", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.integer "recipient_person_id", null: false
+    t.integer "requester_person_id", null: false
+    t.integer "status", default: 0, null: false
+    t.datetime "updated_at", null: false
+    t.index ["recipient_person_id"], name: "index_contact_links_on_recipient_person_id", unique: true
+    t.index ["requester_person_id"], name: "index_contact_links_on_requester_person_id", unique: true
   end
 
   create_table "event_participants", force: :cascade do |t|
@@ -232,6 +242,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_000003) do
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "blocks", "users", column: "blocked_id"
   add_foreign_key "blocks", "users", column: "blocker_id"
+  add_foreign_key "contact_links", "people", column: "recipient_person_id"
+  add_foreign_key "contact_links", "people", column: "requester_person_id"
   add_foreign_key "event_participants", "events"
   add_foreign_key "event_participants", "people"
   add_foreign_key "events", "users"


### PR DESCRIPTION
Users who both know the same person can now link their contact records via a pending/accepted ContactLink. Once accepted, both users see a combined chronological event timeline with per-entry attribution, and each can unlink at any time. The person show page gains an invite form, pending/accepted/requester banners, and a shared history section.