### PR TITLE
Harden gitleaks install against transient download flakes

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -24,9 +24,16 @@ jobs:
       - name: Install gitleaks
         run: |
           set -euo pipefail
-          curl -sSL \
+          # -f makes curl exit non-zero on an HTTP error instead of silently
+          # saving the error page (which used to surface as a confusing
+          # "tar: not in gzip format" failure). --retry + --retry-all-errors
+          # ride out transient GitHub download/CDN hiccups.
+          curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
             -o /tmp/gitleaks.tgz
+          # Fail loudly with a clear message if the download still isn't a gzip.
+          file /tmp/gitleaks.tgz | grep -q gzip \
+            || { echo "::error::Downloaded gitleaks archive is not gzip — aborting"; exit 1; }
           tar -xzf /tmp/gitleaks.tgz -C /tmp gitleaks
           sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version


### PR DESCRIPTION
## Problem

The `secret-scan` (gitleaks) check has been **intermittently failing across branches** — not on a real secret, but in the gitleaks **install** step:

```
gzip: stdin: not in gzip format
tar: Child returned status 1
##[error]Process completed with exit code 2.
```

Root cause: the install step downloads the gitleaks binary with `curl -sSL` (no `-f`). When GitHub's release CDN has a transient hiccup or rate-limits the runner, curl **silently saves the HTTP error page** as `gitleaks.tgz`, and `tar` then fails with the confusing "not in gzip format" message. The pinned version (`8.30.1`) and asset URL are correct — the download itself is what flakes.

Seen today on multiple branches (e.g. `google-calendar-event-links` failed then passed on a plain re-run; `narrow-google-calendar-scopes` #202 hit it too).

## Fix

Harden the install step:
- **`-f`** — curl exits non-zero on an HTTP error instead of saving the error page, so failures are loud and accurate.
- **`--retry 5 --retry-all-errors --retry-delay 2`** — automatically rides out transient download/CDN blips.
- **explicit gzip sanity check** — if the archive somehow still isn't a gzip, fail with a clear `::error::` message instead of a cryptic tar error.

No change to the pinned version, the scan command, or what gets scanned — this only makes the binary download reliable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
