### PR TITLE
Add dismiss + add-to-People buttons on Matches

### DIFF
--- a/app/controllers/meeting_proposals_controller.rb
+++ b/app/controllers/meeting_proposals_controller.rb
@@ -3,7 +3,7 @@
 # only see (and #find) proposals where they are the requester or the recipient.
 class MeetingProposalsController < ApplicationController
   def index
-    @proposals = MeetingProposal.for_user(current_user)
+    @proposals = MeetingProposal.visible_to(current_user)
                                 .includes(:requester, :recipient)
                                 .recent
   end
@@ -12,5 +12,36 @@ class MeetingProposalsController < ApplicationController
     @proposal = MeetingProposal.for_user(current_user)
                                .includes(:requester, :recipient)
                                .find(params[:id])
+  end
+
+  # Remove a match from the current user's Matches screen. Per-viewer: the other
+  # party still sees it. for_user scopes the lookup so a user can only dismiss
+  # their own matches (anything else 404s -> root redirect).
+  def dismiss
+    proposal = MeetingProposal.for_user(current_user).find(params[:id])
+    proposal.dismiss_for(current_user)
+    redirect_to matches_path, notice: "Match dismissed."
+  end
+
+  # One-click add the other party of a match to the current user's People list.
+  # No-ops gracefully if they're already a contact (email is unique per user).
+  def add_to_people
+    proposal = MeetingProposal.for_user(current_user).find(params[:id])
+    other    = proposal.other_party(current_user)
+    return redirect_to(matches_path, alert: "This match has no one to add.") if other.nil?
+
+    existing = current_user.people.where("LOWER(email) = ?", other.email.downcase).first
+    if existing
+      redirect_to person_path(existing), notice: "#{other.display_label} is already in your People."
+    else
+      person = current_user.people.create!(
+        name:     other.display_label,
+        email:    other.email,
+        timezone: other.timezone
+      )
+      redirect_to person_path(person), notice: "Added #{other.display_label} to your People."
+    end
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to matches_path, alert: "Couldn't add to People: #{e.record.errors.full_messages.to_sentence}."
   end
 end

--- a/app/models/meeting_proposal.rb
+++ b/app/models/meeting_proposal.rb
@@ -38,6 +38,17 @@ class MeetingProposal < ApplicationRecord
   scope :for_user, ->(user) {
     where("requester_id = :id OR recipient_id = :id", id: user.id)
   }
+
+  # Proposals to show on a user's Matches screen: ones they're party to AND haven't
+  # dismissed from their OWN view. Dismissal is per-viewer — hiding a match only
+  # removes it from the dismisser's screen, not the other party's.
+  scope :visible_to, ->(user) {
+    where(
+      "(requester_id = :id AND requester_dismissed_at IS NULL) OR " \
+      "(recipient_id = :id AND recipient_dismissed_at IS NULL)",
+      id: user.id
+    )
+  }
   scope :recent, -> { order(created_at: :desc) }
 
   # Has this exact (requester -> recipient) direction been proposed recently?
@@ -59,6 +70,16 @@ class MeetingProposal < ApplicationRecord
   def other_party(user)
     return recipient if user.id == requester_id
     requester
+  end
+
+  # Hide this proposal from the given user's Matches screen (per-viewer; the other
+  # party still sees it). No-op if the user isn't party to the proposal.
+  def dismiss_for(user)
+    if requester_id == user.id
+      update!(requester_dismissed_at: Time.current)
+    elsif recipient_id == user.id
+      update!(recipient_dismissed_at: Time.current)
+    end
   end
 
   private

--- a/app/views/meeting_proposals/_proposal.html.erb
+++ b/app/views/meeting_proposals/_proposal.html.erb
@@ -1,10 +1,12 @@
 <% status_badge = { "accepted" => "bg-success", "declined" => "bg-secondary",
                     "pending" => "bg-warning text-dark", "error" => "bg-danger" } %>
 <% other = proposal.other_party(current_user) %>
-<%= link_to match_path(proposal), class: "list-group-item list-group-item-action",
-      id: dom_id(proposal) do %>
+<%# The row is a plain container (not a link) so the dismiss / add-to-people
+    buttons can sit beside the navigating link instead of nested inside it.
+    Keep dom_id on this element — Turbo Stream broadcasts target it. %>
+<div class="list-group-item" id="<%= dom_id(proposal) %>">
   <div class="d-flex align-items-center justify-content-between">
-    <div class="min-w-0">
+    <%= link_to match_path(proposal), class: "text-reset text-decoration-none flex-grow-1 min-w-0 me-3" do %>
       <div class="fw-semibold text-truncate">
         <% if proposal.error? %>
           <i class="bi bi-exclamation-triangle text-danger me-1"></i>Run failed
@@ -17,12 +19,31 @@
       <div class="text-muted small text-truncate">
         <%= proposal.error? ? proposal.decision_reason : proposal.pitch %>
       </div>
-    </div>
-    <div class="text-end flex-shrink-0 ms-3">
-      <span class="badge <%= status_badge[proposal.status] %>"><%= proposal.status.titleize %></span>
-      <% if proposal.calendar_created? %>
-        <div class="text-success small mt-1"><i class="bi bi-calendar-check"></i> Scheduled</div>
+    <% end %>
+
+    <div class="d-flex align-items-center flex-shrink-0">
+      <div class="text-end me-2">
+        <span class="badge <%= status_badge[proposal.status] %>"><%= proposal.status.titleize %></span>
+        <% if proposal.calendar_created? %>
+          <div class="text-success small mt-1"><i class="bi bi-calendar-check"></i> Scheduled</div>
+        <% end %>
+      </div>
+
+      <% if other %>
+        <%= button_to add_to_people_match_path(proposal), method: :post,
+              class: "btn btn-sm border-0 bg-transparent text-secondary p-1",
+              title: "Add #{other.display_label} to People",
+              aria: { label: "Add #{other.display_label} to People" } do %>
+          <i class="bi bi-person-plus"></i>
+        <% end %>
+      <% end %>
+
+      <%= button_to dismiss_match_path(proposal), method: :patch,
+            class: "btn btn-sm border-0 bg-transparent text-secondary p-1",
+            title: "Dismiss this match",
+            aria: { label: "Dismiss this match" } do %>
+        <i class="bi bi-x-lg"></i>
       <% end %>
     </div>
   </div>
-<% end %>
+</div>

--- a/app/views/meeting_proposals/show.html.erb
+++ b/app/views/meeting_proposals/show.html.erb
@@ -11,9 +11,24 @@
 
 <div class="row justify-content-center">
   <div class="col-md-8">
-    <%= link_to matches_path, class: "btn btn-link btn-sm px-0 mb-2" do %>
-      <i class="bi bi-arrow-left me-1"></i>Back to Matches
-    <% end %>
+    <% other = @proposal.other_party(current_user) %>
+    <div class="d-flex align-items-center justify-content-between mb-2">
+      <%= link_to matches_path, class: "btn btn-link btn-sm px-0" do %>
+        <i class="bi bi-arrow-left me-1"></i>Back to Matches
+      <% end %>
+      <div class="d-flex align-items-center">
+        <% if other %>
+          <%= button_to add_to_people_match_path(@proposal), method: :post,
+                class: "btn btn-sm btn-outline-secondary me-2" do %>
+            <i class="bi bi-person-plus me-1"></i>Add to People
+          <% end %>
+        <% end %>
+        <%= button_to dismiss_match_path(@proposal), method: :patch,
+              class: "btn btn-sm btn-outline-secondary" do %>
+          <i class="bi bi-x-lg me-1"></i>Dismiss
+        <% end %>
+      </div>
+    </div>
 
     <div class="d-flex align-items-center justify-content-between mb-3">
       <h1 class="h5 fw-bold mb-0">
@@ -88,8 +103,7 @@
       </div>
     <% end %>
 
-    <%# Block / Unblock action %>
-    <% other = @proposal.other_party(current_user) %>
+    <%# Block / Unblock action (other is set at the top of the template) %>
     <% if other %>
       <% existing_block = current_user.blocks.find_by(blocked: other) %>
       <div class="d-flex justify-content-end mb-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,7 +33,12 @@ Rails.application.routes.draw do
   delete "/account", to: "registrations#destroy", as: :delete_account
 
   # AI-negotiated meeting matchmaking
-  resources :matches, only: %i[index show], controller: "meeting_proposals"
+  resources :matches, only: %i[index show], controller: "meeting_proposals" do
+    member do
+      patch :dismiss          # hide a match from the current user's screen
+      post  :add_to_people    # one-click add the other party to People
+    end
+  end
   post "matchmaking/run", to: "matchmaking#create", as: :run_matchmaking
 
   resources :people do

--- a/db/migrate/20260608000005_add_dismissal_to_meeting_proposals.rb
+++ b/db/migrate/20260608000005_add_dismissal_to_meeting_proposals.rb
@@ -1,0 +1,9 @@
+class AddDismissalToMeetingProposals < ActiveRecord::Migration[8.1]
+  # Per-viewer dismissal: each party can hide a match from their own Matches
+  # screen without affecting the other party's view. Two nullable timestamps,
+  # one per side; NULL means "not dismissed".
+  def change
+    add_column :meeting_proposals, :requester_dismissed_at, :datetime
+    add_column :meeting_proposals, :recipient_dismissed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -103,8 +103,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_08_120000) do
     t.text "decision_reason"
     t.datetime "meeting_at"
     t.text "pitch"
+    t.datetime "recipient_dismissed_at"
     t.integer "recipient_id"
     t.text "recipient_profile_snapshot"
+    t.datetime "requester_dismissed_at"
     t.integer "requester_id", null: false
     t.text "requester_profile_snapshot"
     t.integer "status", default: 0, null: false

--- a/spec/models/meeting_proposal_spec.rb
+++ b/spec/models/meeting_proposal_spec.rb
@@ -43,6 +43,37 @@ RSpec.describe MeetingProposal, type: :model do
     end
   end
 
+  describe ".visible_to and #dismiss_for" do
+    let(:alice) { create(:user) }
+    let(:bob)   { create(:user) }
+
+    it "hides a match from the dismisser but keeps it for the other party" do
+      proposal = create(:meeting_proposal, requester: alice, recipient: bob)
+
+      proposal.dismiss_for(alice)
+
+      expect(described_class.visible_to(alice)).not_to include(proposal)
+      expect(described_class.visible_to(bob)).to include(proposal)
+    end
+
+    it "is per-side: the requester dismissing doesn't touch the recipient's flag" do
+      proposal = create(:meeting_proposal, requester: alice, recipient: bob)
+
+      proposal.dismiss_for(alice)
+
+      expect(proposal.requester_dismissed_at).to be_present
+      expect(proposal.recipient_dismissed_at).to be_nil
+    end
+
+    it "still authorizes — only returns proposals the user is party to" do
+      mine      = create(:meeting_proposal, requester: alice, recipient: bob)
+      unrelated = create(:meeting_proposal, requester: bob, recipient: create(:user))
+
+      expect(described_class.visible_to(alice)).to include(mine)
+      expect(described_class.visible_to(alice)).not_to include(unrelated)
+    end
+  end
+
   describe ".recently_proposed_between?" do
     let(:alice) { create(:user) }
     let(:bob)   { create(:user) }

--- a/spec/requests/meeting_proposals_spec.rb
+++ b/spec/requests/meeting_proposals_spec.rb
@@ -35,4 +35,56 @@ RSpec.describe "Matches (MeetingProposals)", type: :request do
       expect(response).to redirect_to(root_path)
     end
   end
+
+  describe "PATCH /matches/:id/dismiss" do
+    it "hides the match from the dismisser's list but leaves it for the other party" do
+      proposal = create(:meeting_proposal, requester: user, recipient: other, pitch: "Coffee soon?")
+
+      patch dismiss_match_path(proposal)
+      expect(response).to redirect_to(matches_path)
+
+      get matches_path
+      expect(response.body).not_to include("Coffee soon?")
+
+      # The other party still sees it.
+      sign_in(other)
+      get matches_path
+      expect(response.body).to include("Coffee soon?")
+    end
+
+    it "does not let a non-party dismiss a match" do
+      proposal = create(:meeting_proposal, requester: other, recipient: create(:user))
+      patch dismiss_match_path(proposal)
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "POST /matches/:id/add_to_people" do
+    let(:other) { create(:user, display_name: "Casey Jones", email: "casey@example.com") }
+
+    it "adds the other party to the current user's People and redirects to them" do
+      proposal = create(:meeting_proposal, requester: user, recipient: other)
+
+      expect { post add_to_people_match_path(proposal) }.to change(user.people, :count).by(1)
+
+      person = user.people.order(:created_at).last
+      expect(person.name).to eq("Casey Jones")
+      expect(person.email).to eq("casey@example.com")
+      expect(response).to redirect_to(person_path(person))
+    end
+
+    it "does not create a duplicate when they're already in People" do
+      proposal = create(:meeting_proposal, requester: user, recipient: other)
+      existing = create(:person, user: user, email: "casey@example.com")
+
+      expect { post add_to_people_match_path(proposal) }.not_to change(Person, :count)
+      expect(response).to redirect_to(person_path(existing))
+    end
+
+    it "does not let a non-party add from a match" do
+      proposal = create(:meeting_proposal, requester: other, recipient: create(:user))
+      expect { post add_to_people_match_path(proposal) }.not_to change(Person, :count)
+      expect(response).to redirect_to(root_path)
+    end
+  end
 end


### PR DESCRIPTION
## What

Adds two per-row actions to the **Matches** page (and the match detail page):

- **✕ Dismiss** — hide a match from your own screen.
- **＋ Add to People** (person-plus icon) — one click adds the other party to your People list.

## How it works

### Dismiss is per-viewer (not a delete)
A new migration adds two nullable timestamps, `requester_dismissed_at` / `recipient_dismissed_at`. A new `MeetingProposal.visible_to(user)` scope (which the index now uses, doubling as the auth boundary) hides a match only from the side that dismissed it — the other party still sees it. Because the row isn't destroyed, the anti-spam recency window (`recently_proposed_between?`) keeps working, so dismissing a card doesn't cause you to be immediately re-pitched the same person.

### Add to People is one click and idempotent
`POST /matches/:id/add_to_people` creates a `Person` for the current user from the other user's name / email / timezone. If they're already a contact (email is unique per user, case-insensitive) it just redirects to the existing contact instead of erroring. Non-parties can't dismiss or add from a match they aren't in (scoped via `for_user`, 404 → root, matching the existing show-page authorization).

### Markup / Turbo
The match row used to be one big link, so the buttons are added by un-nesting it: the navigating link and the action buttons are now siblings inside the `_proposal` partial. The partial keeps its `dom_id` and `current_user`-as-local contract, so the existing Turbo Stream broadcast that live-prepends new proposals renders the buttons correctly for each viewer.

## Tests
- Full suite: **250 examples, 0 failures**.
- New request specs: dismiss hides for the dismisser but not the other party; add-to-people creates a contact, no-ops on duplicates, and both reject non-parties.
- New model specs for `visible_to` / `dismiss_for`.
- rubocop + erb_lint clean on changed files.

## Notes
- Branch was rebased onto current `main` (multi-user shared contacts, scheduling negotiations, push notifications, etc.). The migration is timestamped after main's latest.
- Design choice: dismissal is per-viewer rather than clearing the match for both people, since "get rid of them from my screen" implies it shouldn't affect the other user. Easy to flip to a shared dismiss if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
